### PR TITLE
Correct guidance for box shadow spread

### DIFF
--- a/app/components/tool-pallete/model.js
+++ b/app/components/tool-pallete/model.js
@@ -164,7 +164,7 @@ export const ToolModel = {
                     </div>
                     <div>
                       <b>Spread:</b>
-                      <span>Shift + ▲ ▼</span>
+                      <span>Shift + ◀ ▶</span>
                     </div>
                     <div>
                       <b>Opacity:</b>


### PR DESCRIPTION
Box shadow spread is adjusted by using shift-left and shift-right, not shift-up and shift-down. The vertical keys are used for adjusting blur.