### PR TITLE
assign direction and text-align properties to correct layout

### DIFF
--- a/app/components/tool-pallete/toolpallete.element.css
+++ b/app/components/tool-pallete/toolpallete.element.css
@@ -243,6 +243,7 @@
 }
 
 :host li[data-tool="search"] > .search > input {
+  direction: ltr;
   border: none;
   font-size: 1em;
   padding: 0.4em 0.4em 0.4em 2em;

--- a/app/components/tool-pallete/toolpallete.element.css
+++ b/app/components/tool-pallete/toolpallete.element.css
@@ -57,6 +57,8 @@
   & > aside {
     overflow: hidden;
     position: absolute;
+    direction: ltr;
+    text-align: left;
     left: 3em;
     top: 0;
     z-index: -2;


### PR DESCRIPTION
On Arabic and Hebrew websites that have `direction: rtl` and `text-align: right`, the English in this extension receives the same styling as any right-to-left text.

This PR forces correct laying out of text hopefully in all places where it is needed.