### PR TITLE
A11y display contextual text contrast ratings

### DIFF
--- a/app/features/accessibility.js
+++ b/app/features/accessibility.js
@@ -1,7 +1,7 @@
 import $ from 'blingblingjs'
 import hotkeys from 'hotkeys-js'
 import { TinyColor, readability, isReadable } from '@ctrl/tinycolor'
-import { getStyle, isOffBounds, getA11ys, getComputedBackgroundColor } from '../utilities/'
+import { getStyle, getStyles, isOffBounds, getA11ys, getWCAG2TextSize, getComputedBackgroundColor } from '../utilities/'
 
 const tip_map = new Map()
 
@@ -30,13 +30,13 @@ export function Accessibility() {
     // question: how to know if the current node is actually a black background?
     // question: is there an api for composited values?
     const text      = getStyle(el, 'color')
+    const textSize  = getWCAG2TextSize(el)
+
     let background  = getComputedBackgroundColor(el)
 
-    const [ aa_small, aaa_small, aa_large, aaa_large ] = [
-      isReadable(background, text),
-      isReadable(background, text, { level: "AAA", size: "small" }),
-      isReadable(background, text, { level: "AA", size: "large" }),
-      isReadable(background, text, { level: "AAA", size: "large" }),
+    const [ aa_contrast, aaa_contrast ] = [
+      isReadable(background, text, { level: "AA", size: textSize.toLowerCase() }),
+      isReadable(background, text, { level: "AAA", size: textSize.toLowerCase() })
     ]
 
     return `
@@ -47,14 +47,10 @@ export function Accessibility() {
           color:${text};
         ">${Math.floor(readability(background, text)  * 100) / 100}</span>
       </span>
-      <span prop>› AA Small</span>
-      <span value style="${aa_small ? 'color:green;' : 'color:red'}">${aa_small ? '✓' : '×'}</span>
-      <span prop>› AAA Small</span>
-      <span value style="${aaa_small ? 'color:green;' : 'color:red'}">${aaa_small ? '✓' : '×'}</span>
-      <span prop>› AA Large</span>
-      <span value style="${aa_large ? 'color:green;' : 'color:red'}">${aa_large ? '✓' : '×'}</span>
-      <span prop>› AAA Large</span>
-      <span value style="${aaa_large ? 'color:green;' : 'color:red'}">${aaa_large ? '✓' : '×'}</span>
+      <span prop>› AA ${textSize}</span>
+      <span value style="${aa_contrast ? 'color:green;' : 'color:red'}">${aa_contrast ? '✓' : '×'}</span>
+      <span prop>› AAA ${textSize}</span>
+      <span value style="${aaa_contrast ? 'color:green;' : 'color:red'}">${aaa_contrast ? '✓' : '×'}</span>
     `
   }
 

--- a/app/utilities/accessibility.js
+++ b/app/utilities/accessibility.js
@@ -1,4 +1,5 @@
-import { desiredAccessibilityMap } from './design-properties'
+import { desiredAccessibilityMap, desiredPropMap, largeWCAG2TextMap } from './design-properties'
+import { getStyles } from './styles'
 
 export const getA11ys = el => {
   const elAttributes = el.getAttributeNames()
@@ -21,4 +22,23 @@ export const getA11ys = el => {
 
     return acc
   }, [])
+}
+
+export const getWCAG2TextSize = el => {
+  
+  const styles = getStyles(el).reduce((styleMap, style) => {
+      styleMap[style.prop] = style.value
+      return styleMap
+  }, {})
+
+  const { fontSize   = desiredPropMap.fontSize,
+          fontWeight = desiredPropMap.fontWeight
+      } = styles
+  
+  const isLarge = largeWCAG2TextMap.some(
+    (largeProperties) => parseFloat(fontSize) >= parseFloat(largeProperties.fontSize) 
+       && parseFloat(fontWeight) >= parseFloat(largeProperties.fontWeight) 
+  )
+
+  return  isLarge ? 'Large' : 'Small'
 }

--- a/app/utilities/design-properties.js
+++ b/app/utilities/design-properties.js
@@ -33,3 +33,14 @@ export const desiredAccessibilityMap = [
   'alt',
   'title',
 ]
+
+export const largeWCAG2TextMap = [
+  {
+    fontSize: '24px',
+    fontWeight: '0'
+  },
+  {
+    fontSize: '18.5px',
+    fontWeight: '700'
+  }
+]

--- a/app/utilities/index.js
+++ b/app/utilities/index.js
@@ -1,4 +1,4 @@
 export { getStyle, getStyles, getComputedBackgroundColor } from './styles'
-export { getA11ys } from './accessibility'
+export { getA11ys, getWCAG2TextSize } from './accessibility'
 export { getSide, showHideSelected, showHideNodeLabel, htmlStringToDom, isOffBounds } from './common'
 export { camelToDash, nodeKey, createClassname } from './strings' 


### PR DESCRIPTION
Changed A11y metatip to display the contrast test results for either large or small text based on the text's computed font-size and font-weight.

![example](https://user-images.githubusercontent.com/45132184/48667361-ebb5e200-eaa1-11e8-90c6-d8a55ba8cfaf.PNG)

Using this contextual information it will now display only the relevant contrast test results for the text that the user is currently inspecting.