### PR TITLE
add support for german keyboard preference

### DIFF
--- a/app/components/tool-pallete/toolpallete.element.js
+++ b/app/components/tool-pallete/toolpallete.element.js
@@ -59,7 +59,7 @@ export default class ToolPallete extends HTMLElement {
       })
     )
 
-    hotkeys('cmd+/', e =>
+    hotkeys('cmd+/,cmd+.', e =>
       this.$shadow.host.style.display =
         this.$shadow.host.style.display === 'none'
           ? 'block'


### PR DESCRIPTION
adds support for `cmd+.` being a command that also toggles the toolbar's visibility