### PR TITLE
Bump up z-index so toolbar sits above WP admin bar

### DIFF
--- a/app/components/tool-pallete/toolpallete.element.css
+++ b/app/components/tool-pallete/toolpallete.element.css
@@ -4,7 +4,7 @@
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 99998; 
+  z-index: 100000; 
   font-size: 16px;
   font-family: system-ui;
 }

--- a/app/components/tool-pallete/toolpallete.element.css
+++ b/app/components/tool-pallete/toolpallete.element.css
@@ -4,7 +4,7 @@
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 100000; 
+  z-index: 2147483647; 
   font-size: 16px;
   font-family: system-ui;
 }


### PR DESCRIPTION
Toolbar (z-index: 99998) currently sits below WordPress admin bar (z-index: 99999)
Bumped value up by 2 so it will display above.