### PR TITLE
Fix terminology

### DIFF
--- a/app/components/tool-pallete/model.js
+++ b/app/components/tool-pallete/model.js
@@ -199,7 +199,7 @@ export const ToolModel = {
     tool:        'font',
     icon:        Icons.font,
     label:       'Font Styles',
-    description: 'Change size, alignment, leading, kerning, & weight',
+    description: 'Change size, alignment, leading, letter-spacing, & weight',
     instruction: `<div table>
                     <div>
                       <b>Size:</b>
@@ -214,7 +214,7 @@ export const ToolModel = {
                       <span>Shift + ▲ ▼</span>
                     </div>
                     <div>
-                      <b>Kerning:</b>
+                      <b>Letter-spacing:</b>
                       <span>Shift + ◀ ▶</span>
                     </div>
                     <div>


### PR DESCRIPTION
In typography, **kerning** refers to the space between a specific pair of letters, whereas **letter-spacing** refers to the fixed amount of space used by default between **all** letters. Since you are actually modifying letter-spacing, "Letter-spacing" is the correct terminology here.