### PR TITLE
Use wildcard to reduce overhead of adding new images

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -20,19 +20,7 @@
     }
   },
   "web_accessible_resources": [
-    "tuts/accessibility.gif",
-    "tuts/align.gif",
-    "tuts/boxshadow.gif",
-    "tuts/font.gif",
-    "tuts/guides.gif",
-    "tuts/hueshift.gif",
-    "tuts/inspector.gif",
-    "tuts/margin.gif",
-    "tuts/move.gif",
-    "tuts/padding.gif",
-    "tuts/position.gif",
-    "tuts/search.gif",
-    "tuts/text.gif"
+    "tuts/*"
   ],
   "commands": {
     "_execute_browser_action": {


### PR DESCRIPTION
We can simplify the manifest by using a wildcard for the current set of `"web_accessible_resources"`.