### PR TITLE
Fix hotkeys for Margin tool

### DIFF
--- a/app/features/margin.js
+++ b/app/features/margin.js
@@ -35,7 +35,6 @@ export function Margin(visbug) {
 }
 
 export function pushElement(els, direction) {
-  const side = (getSide(direction) === 'Top' || getSide(direction) === 'Bottom') ? 'Top' : 'Left'
   els
     .map(el => showHideSelected(el))
     .map(el => ({

--- a/app/features/margin.js
+++ b/app/features/margin.js
@@ -35,14 +35,15 @@ export function Margin(visbug) {
 }
 
 export function pushElement(els, direction) {
+  const side = (getSide(direction) === 'Top' || getSide(direction) === 'Bottom') ? 'Top' : 'Left'
   els
     .map(el => showHideSelected(el))
     .map(el => ({
       el,
-      style:    'margin' + getSide(direction),
-      current:  parseInt(getStyle(el, 'margin' + getSide(direction)), 10),
+      style:    'margin' + side,
+      current:  parseInt(getStyle(el, 'margin' + side), 10),
       amount:   direction.split('+').includes('shift') ? 10 : 1,
-      negative: direction.split('+').includes('alt'),
+      negative: direction.split('+').includes('down') || direction.split('+').includes('right'),
     }))
     .map(payload =>
       Object.assign(payload, {
@@ -50,8 +51,10 @@ export function pushElement(els, direction) {
           ? payload.current - payload.amount
           : payload.current + payload.amount
       }))
-    .forEach(({el, style, margin}) =>
-      el.style[style] = `${margin < 0 ? 0 : margin}px`)
+    .forEach(({el, style, margin}) =>{
+      return el.style[style] = `${margin}px`
+    }
+      )
 }
 
 export function pushAllElementSides(els, keycommand) {
@@ -59,7 +62,6 @@ export function pushAllElementSides(els, keycommand) {
   let spoof = ''
 
   if (combo.includes('shift'))  spoof = 'shift+' + spoof
-  if (combo.includes('down'))   spoof = 'alt+' + spoof
 
   'up,down,left,right'.split(',')
     .forEach(side => pushElement(els, spoof + side))

--- a/app/features/margin.js
+++ b/app/features/margin.js
@@ -40,10 +40,10 @@ export function pushElement(els, direction) {
     .map(el => showHideSelected(el))
     .map(el => ({
       el,
-      style:    'margin' + side,
-      current:  parseInt(getStyle(el, 'margin' + side), 10),
+      style:    'margin' + getSide(direction),
+      current:  parseInt(getStyle(el, 'margin' + getSide(direction)), 10),
       amount:   direction.split('+').includes('shift') ? 10 : 1,
-      negative: direction.split('+').includes('down') || direction.split('+').includes('right'),
+      negative: direction.split('+').includes('alt'),
     }))
     .map(payload =>
       Object.assign(payload, {

--- a/app/features/margin.js
+++ b/app/features/margin.js
@@ -50,10 +50,7 @@ export function pushElement(els, direction) {
           ? payload.current - payload.amount
           : payload.current + payload.amount
       }))
-    .forEach(({el, style, margin}) =>{
-      return el.style[style] = `${margin}px`
-    }
-      )
+    .forEach(({el, style, margin}) => el.style[style] = `${margin}px`)
 }
 
 export function pushAllElementSides(els, keycommand) {


### PR DESCRIPTION
Hotkeys are fixed for Margin tool. Using only arrow keys adds 1 px and shift + arrow keys adds 10px to the margin for a selected element. It is tested in chrome 72 and it works fine.