### PR TITLE
CSS upgrade to constructable stylesheets

### DIFF
--- a/app/components/_variables.css
+++ b/app/components/_variables.css
@@ -5,4 +5,11 @@
   --theme-purple: hsl(267, 100%, 58%);
   --theme-icon_color: hsl(0,0%,20%);
   --theme-icon_hover-bg: hsl(0,0%,95%);
+
+  --layer-top: 2147483647;
+  --layer-1: 2147483646;
+  --layer-2: 2147483645;
+  --layer-3: 2147483644;
+  --layer-4: 2147483643;
+  --layer-5: 2147483642;
 }

--- a/app/components/hotkey-map/accessibility.element.js
+++ b/app/components/hotkey-map/accessibility.element.js
@@ -11,15 +11,12 @@ export class AccessibilityHotkeys extends HotkeyMap {
     this.tool       = 'accessibility'
   }
 
-  connectedCallback() {}
-
   show() {
     this.$shadow.host.style.display = 'flex'
   }
 
   render() {
     return `
-      ${this.styles()}
       <article>
         <div tool-icon>
           <span>

--- a/app/components/hotkey-map/base.element.css
+++ b/app/components/hotkey-map/base.element.css
@@ -3,7 +3,7 @@
 :host {
   display: none;
   position: fixed;
-  z-index: 99998;
+  z-index: var(--layer-top);
   align-items: center;
   justify-content: center;
   width: 100vw;

--- a/app/components/hotkey-map/base.element.js
+++ b/app/components/hotkey-map/base.element.js
@@ -3,6 +3,10 @@ import hotkeys      from 'hotkeys-js'
 import styles       from './base.element.css'
 import * as Icons   from '../vis-bug/vis-bug.icons'
 import { metaKey, altKey }  from '../../utilities/'
+import $                   from 'blingblingjs'
+import hotkeys             from 'hotkeys-js'
+import * as Icons          from '../vis-bug/vis-bug.icons'
+import { HotkeymapStyles } from '../styles.store'
 
 export class HotkeyMap extends HTMLElement {
 
@@ -34,6 +38,7 @@ export class HotkeyMap extends HTMLElement {
   }
 
   connectedCallback() {
+    this.$shadow.adoptedStyleSheets = [HotkeymapStyles]
     this.$shift  = $('[keyboard] > section > [shift]', this.$shadow)
     this.$ctrl   = $('[keyboard] > section > [ctrl]', this.$shadow)
     this.$alt    = $(`[keyboard] > section > [${altKey}]`, this.$shadow)
@@ -117,7 +122,6 @@ export class HotkeyMap extends HTMLElement {
 
   render() {
     return `
-      ${this.styles()}
       <article>
         <div tool-icon>
           <span>
@@ -160,14 +164,6 @@ export class HotkeyMap extends HTMLElement {
           </div>
         </div>
       </article>
-    `
-  }
-
-  styles() {
-    return `
-      <style>
-        ${styles}
-      </style>
     `
   }
 }

--- a/app/components/hotkey-map/base.element.js
+++ b/app/components/hotkey-map/base.element.js
@@ -1,12 +1,8 @@
-import $            from 'blingblingjs'
-import hotkeys      from 'hotkeys-js'
-import styles       from './base.element.css'
-import * as Icons   from '../vis-bug/vis-bug.icons'
-import { metaKey, altKey }  from '../../utilities/'
 import $                   from 'blingblingjs'
 import hotkeys             from 'hotkeys-js'
 import * as Icons          from '../vis-bug/vis-bug.icons'
 import { HotkeymapStyles } from '../styles.store'
+import { metaKey, altKey } from '../../utilities/'
 
 export class HotkeyMap extends HTMLElement {
 
@@ -18,7 +14,7 @@ export class HotkeyMap extends HTMLElement {
       tab:    ['tab','q','w','e','r','t','y','u','i','o','p','[',']','\\'],
       caps:   ['caps','a','s','d','f','g','h','j','k','l','\'','return'],
       shift:  ['shift','z','x','c','v','b','n','m',',','.','/','shift'],
-      space:  ['ctrl',altKey,'cmd','spacebar','cmd',altKey,'ctrl']
+      space:  [altKey, metaKey, 'spacebar', metaKey, altKey],
     }
 
     this.key_size_model = {
@@ -72,8 +68,7 @@ export class HotkeyMap extends HTMLElement {
     e.stopImmediatePropagation()
 
     this.$shift.attr('pressed', hotkeys.shift)
-    this.$ctrl.attr('pressed', hotkeys.ctrl)
-    this.$alt.attr('pressed', hotkeys.alt)
+    this.$alt.attr('pressed', hotkeys[altKey === 'opt' ? 'alt' : altKey])
     this.$cmd.attr('pressed', hotkeys[metaKey])
     this.$up.attr('pressed', e.code === 'ArrowUp')
     this.$down.attr('pressed', e.code === 'ArrowDown')
@@ -97,7 +92,7 @@ export class HotkeyMap extends HTMLElement {
     if (code === 'ArrowDown')   side = 'the bottom side'
     if (code === 'ArrowLeft')   side = 'the left side'
     if (code === 'ArrowRight')  side = 'the right side'
-    if (hotkeys[metaKey])            side = 'all sides'
+    if (hotkeys[metaKey])       side = 'all sides'
 
     if (hotkeys[metaKey] && code === 'ArrowDown') {
       negative            = 'Subtract'

--- a/app/components/hotkey-map/boxshadow.element.js
+++ b/app/components/hotkey-map/boxshadow.element.js
@@ -11,15 +11,12 @@ export class BoxshadowHotkeys extends HotkeyMap {
     this.tool       = 'boxshadow'
   }
 
-  connectedCallback() {}
-
   show() {
     this.$shadow.host.style.display = 'flex'
   }
 
   render() {
     return `
-      ${this.styles()}
       <article>
         <div tool-icon>
           <span>

--- a/app/components/hotkey-map/guides.element.js
+++ b/app/components/hotkey-map/guides.element.js
@@ -10,15 +10,12 @@ export class GuidesHotkeys extends HotkeyMap {
     this.tool       = 'guides'
   }
 
-  connectedCallback() {}
-
   show() {
     this.$shadow.host.style.display = 'flex'
   }
 
   render() {
     return `
-      ${this.styles()}
       <article>
         <div tool-icon>
           <span>

--- a/app/components/hotkey-map/inspector.element.js
+++ b/app/components/hotkey-map/inspector.element.js
@@ -11,15 +11,12 @@ export class InspectorHotkeys extends HotkeyMap {
     this.tool       = 'inspector'
   }
 
-  connectedCallback() {}
-
   show() {
     this.$shadow.host.style.display = 'flex'
   }
 
   render() {
     return `
-      ${this.styles()}
       <article>
         <div tool-icon>
           <span>

--- a/app/components/hotkey-map/position.element.js
+++ b/app/components/hotkey-map/position.element.js
@@ -11,15 +11,12 @@ export class PositionHotkeys extends HotkeyMap {
     this.tool       = 'position'
   }
 
-  connectedCallback() {}
-
   show() {
     this.$shadow.host.style.display = 'flex'
   }
 
   render() {
     return `
-      ${this.styles()}
       <article>
         <div tool-icon>
           <span>

--- a/app/components/hotkey-map/search.element.js
+++ b/app/components/hotkey-map/search.element.js
@@ -10,15 +10,12 @@ export class SearchHotkeys extends HotkeyMap {
     this.tool       = 'search'
   }
 
-  connectedCallback() {}
-
   show() {
     this.$shadow.host.style.display = 'flex'
   }
 
   render() {
     return `
-      ${this.styles()}
       <article>
         <div tool-icon>
           <span>

--- a/app/components/hotkey-map/text.element.js
+++ b/app/components/hotkey-map/text.element.js
@@ -10,15 +10,12 @@ export class TextHotkeys extends HotkeyMap {
     this.tool       = 'text'
   }
 
-  connectedCallback() {}
-
   show() {
     this.$shadow.host.style.display = 'flex'
   }
 
   render() {
     return `
-      ${this.styles()}
       <article>
         <div tool-icon>
           <span>

--- a/app/components/metatip/ally.element.js
+++ b/app/components/metatip/ally.element.js
@@ -7,7 +7,6 @@ export class Ally extends Metatip {
   
   render({el, ally_attributes, contrast_results}) {
     return `
-      ${this.styles()}
       <figure>
         <h5>${el.nodeName.toLowerCase()}${el.id && '#' + el.id}</h5>
         <div>

--- a/app/components/metatip/metatip.element.css
+++ b/app/components/metatip/metatip.element.css
@@ -2,7 +2,7 @@
 
 :host {
   position: absolute;
-  z-index: 2147483647;
+  z-index: var(--layer-top);
 
   --arrow-width: 15px;
   --arrow-height: 8px;
@@ -142,10 +142,10 @@
   position: relative;
   top: 1px;
   display: inline-block;
-  width: 0.6em;
-  height: 0.6em;
+  width: 1em;
+  height: 1em;
   border-radius: 50%;
-  margin-right: 0.25em;
+  margin-right: .5em;
 }
 
 :host [local-modifications] {

--- a/app/components/metatip/metatip.element.css
+++ b/app/components/metatip/metatip.element.css
@@ -3,9 +3,6 @@
 :host {
   position: absolute;
   z-index: 2147483647;
-  direction: ltr;
-  font-size: 16px;
-  font-family: system-ui;
 
   --arrow-width: 15px;
   --arrow-height: 8px;
@@ -20,6 +17,10 @@
 }
 
 :host figure {
+  all: initial;
+  direction: ltr;
+  font-size: 16px;
+  font-family: system-ui;
   max-width: 50vw;
   background: white;
   color: var(--theme-icon_color);

--- a/app/components/metatip/metatip.element.js
+++ b/app/components/metatip/metatip.element.js
@@ -1,6 +1,6 @@
 import $ from 'blingblingjs'
 import { createClassname } from '../../utilities/'
-import styles from './metatip.element.css'
+import { MetatipStyles } from '../styles.store'
 
 export class Metatip extends HTMLElement {
 
@@ -10,6 +10,7 @@ export class Metatip extends HTMLElement {
   }
 
   connectedCallback() {
+    this.$shadow.adoptedStyleSheets = [MetatipStyles]
     $(this.$shadow.host).on('mouseenter', this.observe.bind(this))
   }
 
@@ -50,7 +51,6 @@ export class Metatip extends HTMLElement {
 
   render({el, width, height, localModifications, notLocalModifications}) {
     return `
-      ${this.styles()}
       <figure>
         <h5>
           <a node>${el.nodeName.toLowerCase()}</a>
@@ -84,14 +84,6 @@ export class Metatip extends HTMLElement {
           </div>
         ` : ''}
       </figure>
-    `
-  }
-
-  styles() {
-    return `
-      <style>
-        ${styles}
-      </style>
     `
   }
 }

--- a/app/components/selection/box-model.element.css
+++ b/app/components/selection/box-model.element.css
@@ -1,0 +1,18 @@
+:host [mask] {
+  pointer-events: none;
+  position: absolute;
+  z-index: var(--layer-5);
+  width: var(--width);
+  height: var(--height);
+  top: var(--top);
+  left: var(--left);
+  background-color: var(--bg);
+  clip-path: polygon(
+    0% 0%, 0% 100%, var(--target-left) 100%,
+    var(--target-left) var(--target-top),
+    var(--offset-right) var(--target-top),
+    var(--offset-right) var(--offset-bottom),
+    0 var(--offset-bottom), 0 100%,
+    100% 100%, 100% 0%
+  );
+}

--- a/app/components/selection/box-model.element.js
+++ b/app/components/selection/box-model.element.js
@@ -1,3 +1,5 @@
+import { BoxModelStyles } from '../styles.store'
+
 export class BoxModel extends HTMLElement {
 
   constructor() {
@@ -6,7 +8,10 @@ export class BoxModel extends HTMLElement {
     this.drawable = {}
   }
 
-  connectedCallback() {}
+  connectedCallback() {
+    this.$shadow.adoptedStyleSheets = [BoxModelStyles]
+  }
+
   disconnectedCallback() {}
 
   set position(payload) {
@@ -47,8 +52,9 @@ export class BoxModel extends HTMLElement {
       this.drawable.stripe = 'hsla(267, 100%, 58%, 80%)'
     }
 
+    this.styles({sides})
+
     return `
-      ${this.styles({sides})}
       <div mask>
         <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">
           <defs>
@@ -63,28 +69,19 @@ export class BoxModel extends HTMLElement {
   }
 
   styles({sides}) {
-    return `
-      <style>
-        :host [mask] {
-          pointer-events: none;
-          position: absolute;
-          z-index: 2147483642;
-          width: ${this.drawable.width}px;
-          height: ${this.drawable.height}px;
-          top: ${this.drawable.top}px;
-          left: ${this.drawable.left}px;
-          background-color: ${this.drawable.bg};
-          clip-path: polygon(
-            0% 0%, 0% 100%, ${sides.left}px 100%,
-            ${sides.left}px ${sides.top}px,
-            ${this.drawable.width - sides.right}px ${sides.top}px,
-            ${this.drawable.width - sides.right}px ${this.drawable.height - sides.bottom}px,
-            0 ${this.drawable.height - sides.bottom}px, 0 100%,
-            100% 100%, 100% 0%
-          );
-        }
-      </style>
-    `
+    this.style.setProperty('--width', `${this.drawable.width}px`)
+    this.style.setProperty('--height', `${this.drawable.height}px`)
+    this.style.setProperty('--top', `${this.drawable.top}px`)
+    this.style.setProperty('--left', `${this.drawable.left}px`)
+    this.style.setProperty('--bg', `${this.drawable.bg}`)
+
+    this.style.setProperty('--target-left', `${sides.left}px`)
+    this.style.setProperty('--target-top', `${sides.top}px`)
+    this.style.setProperty('--target-right', `${sides.right}px`)
+    this.style.setProperty('--target-bottom', `${sides.bottom}px`)
+
+    this.style.setProperty('--offset-right', `${this.drawable.width - sides.right}px`)
+    this.style.setProperty('--offset-bottom', `${this.drawable.height - sides.bottom}px`)
   }
 
   createMeasurements({mode, bounds, sides, color}) {

--- a/app/components/selection/distance.element.css
+++ b/app/components/selection/distance.element.css
@@ -21,7 +21,7 @@
   right: var(--right);
   overflow: visible;
   pointer-events: none;
-  z-index: 2147483646;
+  z-index: var(--layer-3);
   display: flex;
   align-items: center;
   flex-direction: var(--direction);

--- a/app/components/selection/distance.element.css
+++ b/app/components/selection/distance.element.css
@@ -1,0 +1,60 @@
+@import "../_variables.css";
+
+:host {
+  --line-color: var(--theme-purple);
+  --line-base: var(--theme-color);
+  --line-width: 1px;
+  --distance-h: 5px;
+  --distance-w: 5px;
+  --line-w: 1px;
+  --line-h: 1px;
+  font-size: 16px;
+}
+
+:host > figure {
+  margin: 0;
+  position: absolute;
+  height: var(--distance-h);
+  width: var(--distance-w);
+  top: var(--top);
+  left: var(--left);
+  right: var(--right);
+  overflow: visible;
+  pointer-events: none;
+  z-index: 2147483646;
+  display: flex;
+  align-items: center;
+  flex-direction: var(--direction);
+}
+
+:host > figure figcaption {
+  color: white;
+  text-shadow: 0 0.5px 0 hsla(0, 0%, 0%, 0.4);
+  box-shadow: 0 0.5px 0 hsla(0, 0%, 0%, 0.4);
+  background: var(--line-color);
+  border-radius: 1em;
+  text-align: center;
+  line-height: 1.1;
+  font-size: 0.7em;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;
+  padding: 0.25em 0.5em 0.275em;
+  font-variant-numeric: proportional-num oldstyle-nums stacked-fractions slashed-zero;
+}
+
+:host > figure span {
+  background: var(--line-color);
+  height: var(--line-h);
+  width: var(--line-w);
+}
+
+:host > figure div {
+  flex: 2;
+  background: var(--line-color);
+  width: var(--line-w);
+  height: var(--line-h);
+}
+
+:host figure:matches([quadrant="bottom"], [quadrant="right"]) > div:first-of-type,
+:host figure:matches([quadrant="top"], [quadrant="left"]) > div:last-of-type {
+  background: linear-gradient(to var(--quadrant), hotpink 0%, var(--line-color) 100%);
+}

--- a/app/components/selection/distance.element.js
+++ b/app/components/selection/distance.element.js
@@ -5,10 +5,12 @@ export class Distance extends HTMLElement {
   constructor() {
     super()
     this.$shadow = this.attachShadow({mode: 'open'})
-    this.$shadow.adoptedStyleSheets = [DistanceStyles]
   }
 
-  connectedCallback() {}
+  connectedCallback() {
+    this.$shadow.adoptedStyleSheets = [DistanceStyles]
+  }
+  
   disconnectedCallback() {}
 
   set position({line_model, node_label_id}) {

--- a/app/components/selection/distance.element.js
+++ b/app/components/selection/distance.element.js
@@ -1,102 +1,55 @@
+import { DistanceStyles } from '../styles.store'
+
 export class Distance extends HTMLElement {
 
   constructor() {
     super()
     this.$shadow = this.attachShadow({mode: 'open'})
+    this.$shadow.adoptedStyleSheets = [DistanceStyles]
   }
 
   connectedCallback() {}
   disconnectedCallback() {}
 
-  set position(payload) {
-    this.$shadow.innerHTML = this.render(payload)
+  set position({line_model, node_label_id}) {
+    this.styleProps = line_model
+    this.$shadow.innerHTML  = this.render(line_model, node_label_id)
   }
 
-  render({line_model, node_label_id}) {
+  set styleProps({y,x,d,q,v = false, color}) {
+    this.style.setProperty('--top', `${y + window.scrollY}px`)
+    this.style.setProperty('--right', q === 'left' ? `${x}px` : 'auto')
+    this.style.setProperty('--left', q !== 'left' ? `${x}px` : 'auto')
+    this.style.setProperty('--direction', v ? 'column' : 'row')
+    this.style.setProperty('--quadrant', q)
+
+    v
+      ? this.style.setProperty('--distance-h', `${d}px`)
+      : this.style.setProperty('--distance-w', `${d}px`)
+
+     v
+      ? this.style.setProperty('--line-h', `var(--line-w)`)
+      : this.style.setProperty('--line-w', `var(--line-w)`)
+
+    if (color) {
+      this.style.setProperty('--line-color', color === 'pink'
+        ? 'hotpink'
+        : 'hsl(267, 100%, 58%)')
+      this.style.setProperty('--line-base', color === 'pink'
+        ? 'hotpink'
+        : 'hsl(267, 100%, 58%)')
+    }
+  }
+
+  render({q,d}, node_label_id) {
     this.$shadow.host.setAttribute('data-label-id', node_label_id)
+
     return `
-      ${this.styles(line_model)}
-      <figure quadrant="measurements.q">
+      <figure quadrant="${q}">
         <div></div>
-        <figcaption><b>${line_model.d}</b>px</figcaption>
+        <figcaption><b>${d}</b>px</figcaption>
         <div></div>
       </figure>
-    `
-  }
-
-  styles({y,x,d,q,v = false, color}) {
-    const colors = {}
-    if (color) {
-      const single = color === 'pink'
-        ? 'hotpink'
-        : 'hsl(267, 100%, 58%)'
-
-      colors.line = single
-      colors.base = single
-    }
-    else {
-      colors.line = 'hsl(267, 100%, 58%)'
-      colors.base = 'hotpink'
-    }
-
-    return `
-      <style>
-        :host {
-          --line-color: ${colors.line};
-          --line-base: ${colors.base};
-          --line-width: 1px;
-          font-size: 16px;
-        }
-
-        :host > figure {
-          margin: 0;
-          position: absolute;
-          ${v
-            ? `height: ${d}px; width: 5px;`
-            : `min-width: ${d}px; height: 5px;`}
-          top: ${y + window.scrollY}px;
-          ${q === 'left' ? 'right' : 'left'}: ${x}px;
-          overflow: visible;
-          pointer-events: none;
-          z-index: 2147483646;
-          display: flex;
-          align-items: center;
-          flex-direction: ${v ? 'column' : 'row'};
-        }
-
-        :host > figure figcaption {
-          color: white;
-          text-shadow: 0 0.5px 0 hsla(0, 0%, 0%, 0.4);
-          box-shadow: 0 0.5px 0 hsla(0, 0%, 0%, 0.4);
-          background: var(--line-color);
-          border-radius: 1em;
-          text-align: center;
-          line-height: 1.1;
-          font-size: 0.7em;
-          font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;
-          padding: 0.25em 0.5em 0.275em;
-          font-variant-numeric: proportional-num oldstyle-nums stacked-fractions slashed-zero;
-        }
-
-        :host > figure span {
-          background: var(--line-color);
-          ${v
-            ? 'height: var(--line-width); width: 5px;'
-            : 'width: var(--line-width); height: 5px;'}
-        }
-
-        :host > figure div {
-          flex: 2;
-          background: var(--line-color);
-          ${v
-            ? 'width: var(--line-width);'
-            : 'height: var(--line-width);'}
-        }
-
-        :host figure > div${q === 'top' || q === 'left' ? ':last-of-type' : ':first-of-type'} {
-          background: linear-gradient(to ${q}, var(--line-base) 0%, var(--line-color) 100%);
-        }
-      </style>
     `
   }
 }

--- a/app/components/selection/gridlines.element.css
+++ b/app/components/selection/gridlines.element.css
@@ -1,4 +1,4 @@
-/* todo: import z-index */
+@import "../_variables.css";
 
 :host > svg {
   position:fixed;
@@ -6,5 +6,5 @@
   left:0;
   overflow:visible;
   pointer-events:none;
-  z-index:2147483642;
+  z-index:var(--layer-5);
 }

--- a/app/components/selection/gridlines.element.css
+++ b/app/components/selection/gridlines.element.css
@@ -1,0 +1,10 @@
+/* todo: import z-index */
+
+:host > svg {
+  position:fixed;
+  top:0;
+  left:0;
+  overflow:visible;
+  pointer-events:none;
+  z-index:2147483642;
+}

--- a/app/components/selection/gridlines.element.js
+++ b/app/components/selection/gridlines.element.js
@@ -1,10 +1,12 @@
 import { windowBounds } from '../../utilities/'
+import { GridlineStyles } from '../styles.store'
 
 export class Gridlines extends HTMLElement {
 
   constructor() {
     super()
     this.$shadow = this.attachShadow({mode: 'closed'})
+    this.$shadow.adoptedStyleSheets = [GridlineStyles]
   }
 
   connectedCallback() {}
@@ -16,32 +18,32 @@ export class Gridlines extends HTMLElement {
 
   set update({ width, height, top, left }) {
     const { winHeight, winWidth } = windowBounds()
+    const [svg] = this.$shadow.children
+    const [rect,line1,line2,line3,line4] = svg.children
 
     this.$shadow.host.style.display = 'block'
-    const svg = this.$shadow.children[1]
 
     svg.setAttribute('viewBox', `0 0 ${winWidth} ${winHeight}`)
-    svg.children[0].setAttribute('width', width + 'px')
-    svg.children[0].setAttribute('height', height + 'px')
-    svg.children[0].setAttribute('x', left)
-    svg.children[0].setAttribute('y', top)
-    svg.children[1].setAttribute('x1', left)
-    svg.children[1].setAttribute('x2', left)
-    svg.children[2].setAttribute('x1', left + width)
-    svg.children[2].setAttribute('x2', left + width)
-    svg.children[3].setAttribute('y1', top)
-    svg.children[3].setAttribute('y2', top)
-    svg.children[3].setAttribute('x2', winWidth)
-    svg.children[4].setAttribute('y1', top + height)
-    svg.children[4].setAttribute('y2', top + height)
-    svg.children[4].setAttribute('x2', winWidth)
+    rect.setAttribute('width', width + 'px')
+    rect.setAttribute('height', height + 'px')
+    rect.setAttribute('x', left)
+    rect.setAttribute('y', top)
+    line1.setAttribute('x1', left)
+    line1.setAttribute('x2', left)
+    line2.setAttribute('x1', left + width)
+    line2.setAttribute('x2', left + width)
+    line3.setAttribute('y1', top)
+    line3.setAttribute('y2', top)
+    line3.setAttribute('x2', winWidth)
+    line4.setAttribute('y1', top + height)
+    line4.setAttribute('y2', top + height)
+    line4.setAttribute('x2', winWidth)
   }
 
-  render({ x, y, width, height, top, left }) {
+  render({ x, y, width, height }) {
     const { winHeight, winWidth } = windowBounds()
 
     return `
-      ${this.styles({top,left})}
       <svg
         width="100%" height="100%"
         viewBox="0 0 ${winWidth} ${winHeight}"
@@ -58,21 +60,6 @@ export class Gridlines extends HTMLElement {
         <line x1="0" y1="${y}" x2="${winWidth}" y2="${y}" stroke="hotpink" stroke-dasharray="2" stroke-dashoffset="3"></line>
         <line x1="0" y1="${y + height}" x2="${winWidth}" y2="${y + height}" stroke="hotpink" stroke-dasharray="2" stroke-dashoffset="3"></line>
       </svg>
-    `
-  }
-
-  styles({top,left}) {
-    return `
-      <style>
-        :host > svg {
-          position:fixed;
-          top:0;
-          left:0;
-          overflow:visible;
-          pointer-events:none;
-          z-index:2147483642;
-        }
-      </style>
     `
   }
 }

--- a/app/components/selection/gridlines.element.js
+++ b/app/components/selection/gridlines.element.js
@@ -6,10 +6,12 @@ export class Gridlines extends HTMLElement {
   constructor() {
     super()
     this.$shadow = this.attachShadow({mode: 'closed'})
-    this.$shadow.adoptedStyleSheets = [GridlineStyles]
   }
 
-  connectedCallback() {}
+  connectedCallback() {
+    this.$shadow.adoptedStyleSheets = [GridlineStyles]
+  }
+  
   disconnectedCallback() {}
 
   set position(boundingRect) {

--- a/app/components/selection/handles.element.css
+++ b/app/components/selection/handles.element.css
@@ -1,0 +1,8 @@
+:host > svg {
+  position: absolute;
+  top: var(--top);
+  left: var(--left);
+  overflow: visible;
+  pointer-events: none;
+  z-index: 2147483644;
+}

--- a/app/components/selection/handles.element.css
+++ b/app/components/selection/handles.element.css
@@ -1,8 +1,10 @@
+@import "../_variables.css";
+
 :host > svg {
   position: absolute;
   top: var(--top);
   left: var(--left);
   overflow: visible;
   pointer-events: none;
-  z-index: 2147483644;
+  z-index: var(--layer-3);
 }

--- a/app/components/selection/handles.element.js
+++ b/app/components/selection/handles.element.js
@@ -6,12 +6,14 @@ export class Handles extends HTMLElement {
   constructor() {
     super()
     this.$shadow = this.attachShadow({mode: 'closed'})
-    this.$shadow.adoptedStyleSheets = [HandleStyles]
+    this.styles = [HandleStyles]
   }
 
   connectedCallback() {
+    this.$shadow.adoptedStyleSheets = this.styles
     window.addEventListener('resize', this.on_resize.bind(this))
   }
+  
   disconnectedCallback() {
     window.removeEventListener('resize', this.on_resize)
   }

--- a/app/components/selection/handles.element.js
+++ b/app/components/selection/handles.element.js
@@ -1,10 +1,12 @@
 import $ from 'blingblingjs'
+import { HandleStyles } from '../styles.store'
 
 export class Handles extends HTMLElement {
 
   constructor() {
     super()
     this.$shadow = this.attachShadow({mode: 'closed'})
+    this.$shadow.adoptedStyleSheets = [HandleStyles]
   }
 
   connectedCallback() {
@@ -51,9 +53,11 @@ export class Handles extends HTMLElement {
 
   render({ x, y, width, height, top, left }, node_label_id) {
     this.$shadow.host.setAttribute('data-label-id', node_label_id)
-    
+
+    this.style.setProperty('--top', `${top + window.scrollY}px`)
+    this.style.setProperty('--left', `${left}px`)
+
     return `
-      ${this.styles({top,left})}
       <svg
         class="visbug-handles"
         width="${width}" height="${height}"
@@ -70,21 +74,6 @@ export class Handles extends HTMLElement {
         <circle fill="hotpink" cx="${width/2}" cy="${height}" r="2"></circle>
         <circle fill="hotpink" cx="${width}" cy="${height/2}" r="2"></circle>
       </svg>
-    `
-  }
-
-  styles({top,left}) {
-    return `
-      <style>
-        :host > svg {
-          position: absolute;
-          top: ${top + window.scrollY}px;
-          left: ${left}px;
-          overflow: visible;
-          pointer-events: none;
-          z-index: 2147483644;
-        }
-      </style>
     `
   }
 }

--- a/app/components/selection/hover.element.css
+++ b/app/components/selection/hover.element.css
@@ -1,0 +1,12 @@
+:host rect {
+  width: 100%;
+  height: 100%;
+  vector-effect: non-scaling-stroke;
+  stroke: hsl(267, 100%, 58%);
+  stroke-width: 1px;
+  fill: none;
+}
+
+:host > svg {
+  z-index: 2147483642;
+}

--- a/app/components/selection/hover.element.css
+++ b/app/components/selection/hover.element.css
@@ -1,3 +1,5 @@
+@import "../_variables.css";
+
 :host rect {
   width: 100%;
   height: 100%;
@@ -8,5 +10,5 @@
 }
 
 :host > svg {
-  z-index: 2147483642;
+  z-index: var(--layer-5);
 }

--- a/app/components/selection/hover.element.js
+++ b/app/components/selection/hover.element.js
@@ -1,4 +1,3 @@
-import $ from 'blingblingjs'
 import { Handles } from './handles.element'
 import { HandleStyles, HoverStyles } from '../styles.store'
 
@@ -6,13 +5,7 @@ export class Hover extends Handles {
 
   constructor() {
     super()
-    this.$shadow.adoptedStyleSheets = [HandleStyles, HoverStyles]
-  }
-
-  set position({el}) {
-    // const {top, left} = el.getBoundingClientRect()
-    this.style.setProperty('--top', `${top + window.scrollY}px`)
-    this.style.setProperty('--left', `${left}px`)
+    this.styles = [HandleStyles, HoverStyles]
   }
 
   render({ width, height, top, left }) {

--- a/app/components/selection/hover.element.js
+++ b/app/components/selection/hover.element.js
@@ -9,7 +9,13 @@ export class Hover extends Handles {
     this.$shadow.adoptedStyleSheets = [HandleStyles, HoverStyles]
   }
 
-  render({ x, y, width, height, top, left }) {
+  set position({el}) {
+    // const {top, left} = el.getBoundingClientRect()
+    this.style.setProperty('--top', `${top + window.scrollY}px`)
+    this.style.setProperty('--left', `${left}px`)
+  }
+
+  render({ width, height, top, left }) {
     this.style.setProperty('--top', `${top + window.scrollY}px`)
     this.style.setProperty('--left', `${left}px`)
 

--- a/app/components/selection/hover.element.js
+++ b/app/components/selection/hover.element.js
@@ -1,29 +1,19 @@
 import $ from 'blingblingjs'
 import { Handles } from './handles.element'
+import { HandleStyles, HoverStyles } from '../styles.store'
 
 export class Hover extends Handles {
 
   constructor() {
     super()
+    this.$shadow.adoptedStyleSheets = [HandleStyles, HoverStyles]
   }
 
   render({ x, y, width, height, top, left }) {
-    return `
-      ${this.styles({top,left})}
-      <style>
-        :host rect {
-          width: 100%;
-          height: 100%;
-          vector-effect: non-scaling-stroke;
-          stroke: hsl(267, 100%, 58%);
-          stroke-width: 1px;
-          fill: none;
-        }
+    this.style.setProperty('--top', `${top + window.scrollY}px`)
+    this.style.setProperty('--left', `${left}px`)
 
-        :host > svg {
-          z-index: 2147483642;
-        }
-      </style>
+    return `
       <svg width="${width}" height="${height}">
         <rect></rect>
       </svg>

--- a/app/components/selection/label.element.css
+++ b/app/components/selection/label.element.css
@@ -1,0 +1,51 @@
+/* todo: import z-index */
+
+:host {
+  font-size: 16px;
+
+  --top: 0;
+  --left: 0;
+  --max-width: 0;
+}
+
+:host > span {
+  position: absolute;
+  top: var(--top);
+  left: var(--left);
+  max-width: var(--max-width);
+  z-index: 2147483643;
+  transform: translateY(-100%);
+  background: var(--label-bg, hotpink);
+  border-radius: 0.2em 0.2em 0 0;
+  text-shadow: 0 0.5px 0 hsla(0, 0%, 0%, 0.4);
+  color: white;
+  display: inline-flex;
+  justify-content: center;
+  font-size: 0.8em;
+  font-weight: normal;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;
+  white-space: nowrap;
+  padding: 0.25em 0.4em 0.15em;
+  line-height: 1.1;
+}
+
+:host a {
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+  text-overflow: ellipsis;
+  overflow: hidden;
+
+  &:hover {
+    text-decoration: underline;
+    color: white;
+  }
+
+  &[node]:before {
+    content: "\003c";
+  }
+
+  &[node]:after {
+    content: "\003e";
+  }
+}

--- a/app/components/selection/label.element.css
+++ b/app/components/selection/label.element.css
@@ -1,4 +1,4 @@
-/* todo: import z-index */
+@import "../_variables.css";
 
 :host {
   font-size: 16px;
@@ -13,7 +13,7 @@
   top: var(--top);
   left: var(--left);
   max-width: var(--max-width);
-  z-index: 2147483643;
+  z-index: var(--layer-4);
   transform: translateY(-100%);
   background: var(--label-bg, hotpink);
   border-radius: 0.2em 0.2em 0 0;

--- a/app/components/selection/label.element.js
+++ b/app/components/selection/label.element.js
@@ -1,10 +1,12 @@
 import $ from 'blingblingjs'
+import { LabelStyles } from '../styles.store'
 
 export class Label extends HTMLElement {
 
   constructor() {
     super()
     this.$shadow = this.attachShadow({mode: 'closed'})
+    this.$shadow.adoptedStyleSheets = [LabelStyles]
   }
 
   connectedCallback() {
@@ -46,76 +48,20 @@ export class Label extends HTMLElement {
   }
 
   set position({boundingRect, node_label_id}) {
-    this.$shadow.innerHTML  = this.render(boundingRect, node_label_id)
+    this.$shadow.innerHTML = this.render(node_label_id)
+    this.update = boundingRect
   }
 
-  set update({x,y}) {
-    const label = this.$shadow.children[1]
-    label.style.top  = y + window.scrollY + 'px'
-    label.style.left = x - 1 + 'px'
+  set update({x,y,width}) {
+    this.style.setProperty('--top', `${y + window.scrollY}px`)
+    this.style.setProperty('--left', `${x - 1}px`)
+    this.style.setProperty('--max-width', `${width + (window.innerWidth - x - width - 20)}px`)
   }
 
-  render({ x, y, width, height, top, left }, node_label_id) {
+  render(node_label_id) {
     this.$shadow.host.setAttribute('data-label-id', node_label_id)
 
-    return `
-      ${this.styles({top,left,width})}
-      <span>
-        ${this._text}
-      </span>
-    `
-  }
-
-  styles({top,left,width}) {
-    return `
-      <style>
-        :host {
-          font-size: 16px;
-        }
-
-        :host > span {
-          position: absolute;
-          top: ${top + window.scrollY}px;
-          left: ${left - 1}px;
-          max-width: ${width + (window.innerWidth - left - width - 20)}px;
-          z-index: 2147483643;
-          transform: translateY(-100%);
-          background: var(--label-bg, hotpink);
-          border-radius: 0.2em 0.2em 0 0;
-          text-shadow: 0 0.5px 0 hsla(0, 0%, 0%, 0.4);
-          color: white;
-          display: inline-flex;
-          justify-content: center;
-          font-size: 0.8em;
-          font-weight: normal;
-          font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;
-          white-space: nowrap;
-          padding: 0.25em 0.4em 0.15em;
-          line-height: 1.1;
-        }
-
-        :host a {
-          text-decoration: none;
-          color: inherit;
-          cursor: pointer;
-          text-overflow: ellipsis;
-          overflow: hidden;
-        }
-
-        :host a:hover {
-          text-decoration: underline;
-          color: white;
-        }
-
-        :host a[node]:before {
-          content: "\\003c";
-        }
-
-        :host a[node]:after {
-          content: "\\003e";
-        }
-      </style>
-    `
+    return `<span>${this._text}</span>`
   }
 }
 

--- a/app/components/selection/label.element.js
+++ b/app/components/selection/label.element.js
@@ -6,10 +6,10 @@ export class Label extends HTMLElement {
   constructor() {
     super()
     this.$shadow = this.attachShadow({mode: 'closed'})
-    this.$shadow.adoptedStyleSheets = [LabelStyles]
   }
 
   connectedCallback() {
+    this.$shadow.adoptedStyleSheets = [LabelStyles]
     $('a', this.$shadow).on('click mouseenter', this.dispatchQuery.bind(this))
     window.addEventListener('resize', this.on_resize.bind(this))
   }

--- a/app/components/selection/overlay.element.css
+++ b/app/components/selection/overlay.element.css
@@ -1,4 +1,4 @@
-/* todo: import z-index */
+@import "../_variables.css";
 
 :host svg {
   display: none;
@@ -7,7 +7,7 @@
   left: var(--left);
   overflow: visible;
   pointer-events: none;
-  z-index: 999;
+  z-index: var(--layer-5);
 
   & > rect {
     fill: hsla(330, 100%, 71%, 0.5);

--- a/app/components/selection/overlay.element.css
+++ b/app/components/selection/overlay.element.css
@@ -1,0 +1,17 @@
+/* todo: import z-index */
+
+:host svg {
+  display: none;
+  position: absolute;
+  top: var(--top);
+  left: var(--left);
+  overflow: visible;
+  pointer-events: none;
+  z-index: 999;
+
+  & > rect {
+    fill: hsla(330, 100%, 71%, 0.5);
+    width: 100%;
+    height: 100%;
+  }
+}

--- a/app/components/selection/overlay.element.js
+++ b/app/components/selection/overlay.element.js
@@ -5,10 +5,12 @@ export class Overlay extends HTMLElement {
   constructor() {
     super()
     this.$shadow = this.attachShadow({mode: 'closed'})
-    this.$shadow.adoptedStyleSheets = [OverlayStyles]
   }
 
-  connectedCallback() {}
+  connectedCallback() {
+    this.$shadow.adoptedStyleSheets = [OverlayStyles]
+  }
+  
   disconnectedCallback() {}
 
   set position(boundingRect) {

--- a/app/components/selection/overlay.element.js
+++ b/app/components/selection/overlay.element.js
@@ -1,51 +1,40 @@
+import { OverlayStyles } from '../styles.store'
+
 export class Overlay extends HTMLElement {
-  
+
   constructor() {
     super()
     this.$shadow = this.attachShadow({mode: 'closed'})
+    this.$shadow.adoptedStyleSheets = [OverlayStyles]
   }
 
   connectedCallback() {}
   disconnectedCallback() {}
 
   set position(boundingRect) {
-    this.$shadow.innerHTML  = this.render(boundingRect)
+    this.$shadow.innerHTML = this.render(boundingRect)
   }
 
   set update({ top, left, width, height }) {
-    this.$shadow.host.style.display = 'block'
+    const [svg] = this.$shadow.children
 
-    const svg = this.$shadow.children[0]
+    this.$shadow.host.style.display = 'block'
     svg.style.display = 'block'
-    svg.style.top = window.scrollY + top + 'px'
-    svg.style.left = left + 'px'
+
+    this.style.setProperty('--top', `${top + window.scrollY}px`)
+    this.style.setProperty('--left', `${left - 1}px`)
 
     svg.setAttribute('width', width + 'px')
     svg.setAttribute('height', height + 'px')
   }
 
-  render({id, top, left, height, width}) {
+  render({height, width}) {
     return `
-      <svg 
-        class="visbug-overlay"
-        overlay-id="${id}"
-        style="
-          display:none;
-          position:absolute;
-          top:0;
-          left:0;
-          overflow:visible;
-          pointer-events:none;
-          z-index: 999;
-        " 
-        width="${width}px" height="${height}px" 
-        viewBox="0 0 ${width} ${height}" 
-        version="1.1" xmlns="http://www.w3.org/2000/svg"
+      <svg class="visbug-overlay"
+        width="${width}px" height="${height}px"
+        viewBox="0 0 ${width} ${height}"
       >
-        <rect 
-          fill="hsla(330, 100%, 71%, 0.5)"
-          width="100%" height="100%"
-        ></rect>
+        <rect></rect>
       </svg>
     `
   }

--- a/app/components/styles.store.js
+++ b/app/components/styles.store.js
@@ -1,0 +1,27 @@
+import { default as handle_css }   from './selection/handles.element.css'
+import { default as hover_css }    from './selection/hover.element.css'
+import { default as distance_css } from './selection/distance.element.css'
+import { default as gridline_css } from './selection/gridlines.element.css'
+import { default as label_css }    from './selection/label.element.css'
+import { default as overlay_css }  from './selection/overlay.element.css'
+
+const constructStylesheet = (styles, stylesheet = new CSSStyleSheet()) => {
+  stylesheet.replaceSync(styles)
+  return stylesheet
+}
+
+const HandleStyles   = constructStylesheet(handle_css)
+const HoverStyles    = constructStylesheet(hover_css)
+const DistanceStyles = constructStylesheet(distance_css)
+const GridlineStyles = constructStylesheet(gridline_css)
+const LabelStyles    = constructStylesheet(label_css)
+const OverlayStyles  = constructStylesheet(overlay_css)
+
+export {
+  HandleStyles,
+  HoverStyles,
+  DistanceStyles,
+  GridlineStyles,
+  LabelStyles,
+  OverlayStyles,
+}

--- a/app/components/styles.store.js
+++ b/app/components/styles.store.js
@@ -6,6 +6,7 @@ import { default as gridline_css }   from './selection/gridlines.element.css'
 import { default as label_css }      from './selection/label.element.css'
 import { default as overlay_css }    from './selection/overlay.element.css'
 import { default as boxmodel_css }   from './selection/box-model.element.css'
+import { default as metatip_css }    from './metatip/metatip.element.css'
 import { default as hotkeymap_css }  from './hotkey-map/base.element.css'
 
 const constructStylesheet = (styles, stylesheet = new CSSStyleSheet()) => {
@@ -16,6 +17,7 @@ const constructStylesheet = (styles, stylesheet = new CSSStyleSheet()) => {
 export const VisBugStyles    = constructStylesheet(visbug_css)
 export const HandleStyles    = constructStylesheet(handle_css)
 export const HoverStyles     = constructStylesheet(hover_css)
+export const MetatipStyles   = constructStylesheet(metatip_css)
 export const DistanceStyles  = constructStylesheet(distance_css)
 export const GridlineStyles  = constructStylesheet(gridline_css)
 export const LabelStyles     = constructStylesheet(label_css)

--- a/app/components/styles.store.js
+++ b/app/components/styles.store.js
@@ -5,6 +5,7 @@ import { default as distance_css }   from './selection/distance.element.css'
 import { default as gridline_css }   from './selection/gridlines.element.css'
 import { default as label_css }      from './selection/label.element.css'
 import { default as overlay_css }    from './selection/overlay.element.css'
+import { default as boxmodel_css }   from './selection/box-model.element.css'
 import { default as hotkeymap_css }  from './hotkey-map/base.element.css'
 
 const constructStylesheet = (styles, stylesheet = new CSSStyleSheet()) => {
@@ -19,4 +20,5 @@ export const DistanceStyles  = constructStylesheet(distance_css)
 export const GridlineStyles  = constructStylesheet(gridline_css)
 export const LabelStyles     = constructStylesheet(label_css)
 export const OverlayStyles   = constructStylesheet(overlay_css)
+export const BoxModelStyles  = constructStylesheet(boxmodel_css)
 export const HotkeymapStyles = constructStylesheet(hotkeymap_css)

--- a/app/components/styles.store.js
+++ b/app/components/styles.store.js
@@ -1,27 +1,22 @@
-import { default as handle_css }   from './selection/handles.element.css'
-import { default as hover_css }    from './selection/hover.element.css'
-import { default as distance_css } from './selection/distance.element.css'
-import { default as gridline_css } from './selection/gridlines.element.css'
-import { default as label_css }    from './selection/label.element.css'
-import { default as overlay_css }  from './selection/overlay.element.css'
+import { default as visbug_css }     from './vis-bug/vis-bug.element.css'
+import { default as handle_css }     from './selection/handles.element.css'
+import { default as hover_css }      from './selection/hover.element.css'
+import { default as distance_css }   from './selection/distance.element.css'
+import { default as gridline_css }   from './selection/gridlines.element.css'
+import { default as label_css }      from './selection/label.element.css'
+import { default as overlay_css }    from './selection/overlay.element.css'
+import { default as hotkeymap_css }  from './hotkey-map/base.element.css'
 
 const constructStylesheet = (styles, stylesheet = new CSSStyleSheet()) => {
   stylesheet.replaceSync(styles)
   return stylesheet
 }
 
-const HandleStyles   = constructStylesheet(handle_css)
-const HoverStyles    = constructStylesheet(hover_css)
-const DistanceStyles = constructStylesheet(distance_css)
-const GridlineStyles = constructStylesheet(gridline_css)
-const LabelStyles    = constructStylesheet(label_css)
-const OverlayStyles  = constructStylesheet(overlay_css)
-
-export {
-  HandleStyles,
-  HoverStyles,
-  DistanceStyles,
-  GridlineStyles,
-  LabelStyles,
-  OverlayStyles,
-}
+export const VisBugStyles    = constructStylesheet(visbug_css)
+export const HandleStyles    = constructStylesheet(handle_css)
+export const HoverStyles     = constructStylesheet(hover_css)
+export const DistanceStyles  = constructStylesheet(distance_css)
+export const GridlineStyles  = constructStylesheet(gridline_css)
+export const LabelStyles     = constructStylesheet(label_css)
+export const OverlayStyles   = constructStylesheet(overlay_css)
+export const HotkeymapStyles = constructStylesheet(hotkeymap_css)

--- a/app/components/vis-bug/vis-bug.element.css
+++ b/app/components/vis-bug/vis-bug.element.css
@@ -11,6 +11,9 @@
 }
 
 :host > ol {
+  all: initial;
+  font-size: 16px;
+  font-family: system-ui;
   display: flex;
   flex-direction: column;
   margin: 1em 0 0.5em 1em;

--- a/app/components/vis-bug/vis-bug.element.css
+++ b/app/components/vis-bug/vis-bug.element.css
@@ -89,7 +89,7 @@
     & figcaption {
       padding: 1em;
       display: grid;
-      grid-gap: 0.5em;
+      gap: 0.5em;
 
       & > :matches(h2,p) {
         margin: 0;
@@ -113,7 +113,7 @@
 
       & [table] {
         display: grid;
-        grid-gap: 0.5em;
+        gap: 0.5em;
 
         & > div {
           display: grid;

--- a/app/components/vis-bug/vis-bug.element.css
+++ b/app/components/vis-bug/vis-bug.element.css
@@ -4,10 +4,8 @@
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 2147483646;
+  z-index: var(--layer-1);
   max-width: min-content;
-  font-size: 16px;
-  font-family: system-ui;
 }
 
 :host > ol {

--- a/app/components/vis-bug/vis-bug.element.js
+++ b/app/components/vis-bug/vis-bug.element.js
@@ -13,7 +13,8 @@ import {
   Guides, Screenshot, Position, Accessibility
 } from '../../features/'
 
-import { VisBugModel }              from './model'
+import { VisBugStyles }           from '../styles.store'
+import { VisBugModel }            from './model'
 import * as Icons                 from './vis-bug.icons'
 import { provideSelectorEngine }  from '../../features/search'
 import { metaKey }                from '../../utilities/'
@@ -28,6 +29,8 @@ export default class VisBug extends HTMLElement {
   }
 
   connectedCallback() {
+    this.$shadow.adoptedStylesheeets = [VisBugStyles]
+
     if (!this.$shadow.innerHTML)
       this.setup()
 

--- a/app/components/vis-bug/vis-bug.element.js
+++ b/app/components/vis-bug/vis-bug.element.js
@@ -1,6 +1,5 @@
 import $          from 'blingblingjs'
 import hotkeys    from 'hotkeys-js'
-import styles     from './vis-bug.element.css'
 
 import {
   Handles, Label, Overlay, Gridlines,
@@ -29,7 +28,7 @@ export default class VisBug extends HTMLElement {
   }
 
   connectedCallback() {
-    this.$shadow.adoptedStylesheeets = [VisBugStyles]
+    this.$shadow.adoptedStyleSheets = [VisBugStyles]
 
     if (!this.$shadow.innerHTML)
       this.setup()
@@ -108,7 +107,6 @@ export default class VisBug extends HTMLElement {
 
   render() {
     return `
-      ${this.styles()}
       <visbug-hotkeys></visbug-hotkeys>
       <ol>
         ${Object.entries(this.toolbar_model).reduce((list, [key, tool]) => `
@@ -133,14 +131,6 @@ export default class VisBug extends HTMLElement {
           ${Icons.color_border}
         </li>
       </ol>
-    `
-  }
-
-  styles() {
-    return `
-      <style>
-        ${styles}
-      </style>
     `
   }
 

--- a/app/demo/layout.css
+++ b/app/demo/layout.css
@@ -115,6 +115,12 @@ main {
   width: 100%;
   grid-template-columns: repeat(5, 5rem);
   justify-content: space-around;
+
+  & > .filled-circle:nth-child(1) { background: hsl(200, 50%, 50%); }
+  & > .filled-circle:nth-child(2) { background: hsl(225, 50%, 50%); }
+  & > .filled-circle:nth-child(3) { background: hsl(250, 50%, 50%); }
+  & > .filled-circle:nth-child(4) { background: hsl(275, 50%, 50%); }
+  & > .filled-circle:nth-child(5) { background: hsl(300, 50%, 50%); }
 }
 
 nav {

--- a/app/features/selectable.js
+++ b/app/features/selectable.js
@@ -556,9 +556,8 @@ export function Selectable() {
         hover_state.element.remove()
 
       hover_state.element = document.createElement('visbug-hover')
-      hover_state.element.position = {el}
-
       document.body.appendChild(hover_state.element)
+      hover_state.element.position = {el}
 
       return hover_state.element
     }
@@ -570,6 +569,7 @@ export function Selectable() {
         hover_state.label.remove()
 
       hover_state.label = document.createElement('visbug-label')
+      document.body.appendChild(hover_state.label)
 
       hover_state.label.text = text
       hover_state.label.position = {
@@ -579,7 +579,6 @@ export function Selectable() {
 
       hover_state.label.style.setProperty(`--label-bg`, `hsl(267, 100%, 58%)`)
 
-      document.body.appendChild(hover_state.label)
 
       return hover_state.label
     }

--- a/app/features/selectable.js
+++ b/app/features/selectable.js
@@ -577,7 +577,7 @@ export function Selectable() {
         node_label_id:  'hover',
       }
 
-      hover_state.label.style = `--label-bg: hsl(267, 100%, 58%)`
+      hover_state.label.style.setProperty(`--label-bg`, `hsl(267, 100%, 58%)`)
 
       document.body.appendChild(hover_state.label)
 


### PR DESCRIPTION
was able to get over the chrome bug that blocked this PR by changing a few ops around. there's a lot about organization to be gained here, and i'm really curious what the perf wins are.

https://visbug-css-upgrade.glitch.me - deployed PR for testing
https://googlechromelabs-projectvisbug.glitch.me - master branch 

**strategy is as follows**
- when CSS is imported via js, rollup hands it to postCSS first for transformation
- during this transpilation, vars can be shared and all sorts of other goodness
- the result is a string given to js
- these strings are managed in the styles store here https://github.com/GoogleChromeLabs/ProjectVisBug/pull/325/files#diff-8d68e2efae2f63f040efcf61627dd9b4
- the styles store creates and manages all constructable stylesheets
- components request a stylesheet from the store and adopt it as needed

**this allowed**
- all styles to be written as external stylesheets and gain all the highlighting
- composable styles, some components like the hover element, extend a base component and then adopt an additional stylesheet
- render functions to be just render functions

i dont think this PR is done yet, but it's close enough to share and QA 👍 
thoughts? 