### PR TITLE
Display container layout in Alignment tool (#36)

### DIFF
--- a/app/features/flex.js
+++ b/app/features/flex.js
@@ -57,8 +57,12 @@ const ensureFlex = el => {
   return el
 }
 
-export const assignLabel = (el) => $(el).attr('data-label', `display: ${getComputedStyle(el).display}`)
-export const onSelectedUpdateHandler = (els) => els.forEach(assignLabel)
+export const assignLabel = (el) => { 
+  $(el).attr('data-label', `display: ${getComputedStyle(el).display}`)
+  return el
+} 
+
+export const onSelectedUpdateHandler = (el) => el.forEach(assignLabel)
 
 const accountForOtherJustifyContent = (cur, want) => {
   if (want == 'align' && (cur != 'flex-start' && cur != 'center' && cur != 'flex-end'))

--- a/app/features/flex.js
+++ b/app/features/flex.js
@@ -1,3 +1,4 @@
+import $ from 'blingblingjs'
 import hotkeys from 'hotkeys-js'
 import { metaKey, getStyle } from '../utilities/'
 
@@ -10,13 +11,13 @@ const key_events = 'up,down,left,right'
 
 const command_events = `${metaKey}+up,${metaKey}+down,${metaKey}+left,${metaKey}+right`
 
-export function Flex({selection}) {
+export function Flex(visbug) {
   hotkeys(key_events, (e, handler) => {
     if (e.cancelBubble) return
 
     e.preventDefault()
 
-    let selectedNodes = selection()
+    let selectedNodes = visbug.selection()
       , keys = handler.key.split('+')
 
     if (keys.includes('left') || keys.includes('right'))
@@ -32,7 +33,7 @@ export function Flex({selection}) {
   hotkeys(command_events, (e, handler) => {
     e.preventDefault()
 
-    let selectedNodes = selection()
+    let selectedNodes = visbug.selection()
       , keys = handler.key.split('+')
 
     if (keys.includes('left') || keys.includes('right'))
@@ -41,16 +42,26 @@ export function Flex({selection}) {
       changeDirection(selectedNodes, 'column')
   })
 
+  visbug.onSelectedUpdate(onSelectedUpdateHandler)
+
   return () => {
     hotkeys.unbind(key_events)
     hotkeys.unbind(command_events)
     hotkeys.unbind('up,down,left,right')
+    visbug.removeSelectedCallback(onSelectedUpdateHandler)
   }
 }
 
-const ensureFlex = el => {
-  el.style.display = 'flex'
-  return el
+export const ensureFlex = (el) => el.style.display = 'flex'
+export const assignLabel = (el) => $(el).attr('data-label', `display: ${getComputedStyle(el).display}`)
+
+const assignLabelAndEnsureFlex = callback => (els, ...args) => {
+  els.forEach(el => { 
+    ensureFlex(el)
+    assignLabel(el)
+  })
+
+  return callback(els, ...args)
 }
 
 const accountForOtherJustifyContent = (cur, want) => {
@@ -63,98 +74,98 @@ const accountForOtherJustifyContent = (cur, want) => {
 }
 
 // todo: support reversing direction
-export function changeDirection(els, value) {
-  els
-    .map(ensureFlex)
-    .map(el => {
-      el.style.flexDirection = value
-    })
-}
+export const changeDirection = assignLabelAndEnsureFlex(
+  (els, value) => els.forEach(el => el.style.flexDirection = value)
+);
 
 const h_alignMap      = {normal: 0,'flex-start': 0,'center': 1,'flex-end': 2,}
 const h_alignOptions  = ['flex-start','center','flex-end']
 
-export function changeHAlignment(els, direction) {
-  els
-    .map(ensureFlex)
-    .map(el => ({
-      el,
-      style:    'justifyContent',
-      current:  accountForOtherJustifyContent(getStyle(el, 'justifyContent'), 'align'),
-      direction: direction.split('+').includes('left'),
-    }))
-    .map(payload =>
-      Object.assign(payload, {
-        value: payload.direction
-          ? h_alignMap[payload.current] - 1
-          : h_alignMap[payload.current] + 1
+export const changeHAlignment = assignLabelAndEnsureFlex(
+  (els, direction) => 
+    els
+      .map(el => ({
+        el,
+        style:    'justifyContent',
+        current:  accountForOtherJustifyContent(getStyle(el, 'justifyContent'), 'align'),
+        direction: direction.split('+').includes('left'),
       }))
-    .forEach(({el, style, value}) =>
-      el.style[style] = h_alignOptions[value < 0 ? 0 : value >= 2 ? 2: value])
-}
+      .map(payload =>
+        Object.assign(payload, {
+          value: payload.direction
+            ? h_alignMap[payload.current] - 1
+            : h_alignMap[payload.current] + 1
+        }))
+      .forEach(({el, style, value}) =>
+        el.style[style] = h_alignOptions[value < 0 ? 0 : value >= 2 ? 2: value])
+)
 
 const v_alignMap      = {normal: 0,'flex-start': 0,'center': 1,'flex-end': 2,}
 const v_alignOptions  = ['flex-start','center','flex-end']
 
-export function changeVAlignment(els, direction) {
-  els
-    .map(ensureFlex)
-    .map(el => ({
-      el,
-      style:    'alignItems',
-      current:  getStyle(el, 'alignItems'),
-      direction: direction.split('+').includes('up'),
-    }))
-    .map(payload =>
-      Object.assign(payload, {
-        value: payload.direction
-          ? h_alignMap[payload.current] - 1
-          : h_alignMap[payload.current] + 1
+export const changeVAlignment = assignLabelAndEnsureFlex(
+  (els, direction) => 
+    els
+      .map(el => ({
+        el,
+        style:    'alignItems',
+        current:  getStyle(el, 'alignItems'),
+        direction: direction.split('+').includes('up'),
       }))
-    .forEach(({el, style, value}) =>
-      el.style[style] = v_alignOptions[value < 0 ? 0 : value >= 2 ? 2: value])
-}
+      .map(payload =>
+        Object.assign(payload, {
+          value: payload.direction
+            ? h_alignMap[payload.current] - 1
+            : h_alignMap[payload.current] + 1
+        }))
+      .forEach(({el, style, value}) =>
+        el.style[style] = v_alignOptions[value < 0 ? 0 : value >= 2 ? 2: value])
+)
 
 const h_distributionMap      = {normal: 1,'space-around': 0,'': 1,'space-between': 2,}
 const h_distributionOptions  = ['space-around','','space-between']
 
-export function changeHDistribution(els, direction) {
-  els
-    .map(ensureFlex)
-    .map(el => ({
-      el,
-      style:    'justifyContent',
-      current:  accountForOtherJustifyContent(getStyle(el, 'justifyContent'), 'distribute'),
-      direction: direction.split('+').includes('left'),
-    }))
-    .map(payload =>
-      Object.assign(payload, {
-        value: payload.direction
-          ? h_distributionMap[payload.current] - 1
-          : h_distributionMap[payload.current] + 1
+export const changeHDistribution = assignLabelAndEnsureFlex(
+  (els, direction) => 
+    els
+      .map(el => ({
+        el,
+        style:    'justifyContent',
+        current:  accountForOtherJustifyContent(getStyle(el, 'justifyContent'), 'distribute'),
+        direction: direction.split('+').includes('left'),
       }))
-    .forEach(({el, style, value}) =>
-      el.style[style] = h_distributionOptions[value < 0 ? 0 : value >= 2 ? 2: value])
-}
+      .map(payload =>
+        Object.assign(payload, {
+          value: payload.direction
+            ? h_distributionMap[payload.current] - 1
+            : h_distributionMap[payload.current] + 1
+        }))
+      .forEach(({el, style, value}) =>
+        el.style[style] = h_distributionOptions[value < 0 ? 0 : value >= 2 ? 2: value])
+)
 
 const v_distributionMap      = {normal: 1,'space-around': 0,'': 1,'space-between': 2,}
 const v_distributionOptions  = ['space-around','','space-between']
 
-export function changeVDistribution(els, direction) {
-  els
-    .map(ensureFlex)
-    .map(el => ({
-      el,
-      style:    'alignContent',
-      current:  getStyle(el, 'alignContent'),
-      direction: direction.split('+').includes('up'),
-    }))
-    .map(payload =>
-      Object.assign(payload, {
-        value: payload.direction
-          ? v_distributionMap[payload.current] - 1
-          : v_distributionMap[payload.current] + 1
+export const changeVDistribution = assignLabelAndEnsureFlex(
+  (els, direction) =>
+    els
+      .map(el => ({
+        el,
+        style:    'alignContent',
+        current:  getStyle(el, 'alignContent'),
+        direction: direction.split('+').includes('up'),
       }))
-    .forEach(({el, style, value}) =>
-      el.style[style] = v_distributionOptions[value < 0 ? 0 : value >= 2 ? 2: value])
+      .map(payload =>
+        Object.assign(payload, {
+          value: payload.direction
+            ? v_distributionMap[payload.current] - 1
+            : v_distributionMap[payload.current] + 1
+        }))
+      .forEach(({el, style, value}) =>
+        el.style[style] = v_distributionOptions[value < 0 ? 0 : value >= 2 ? 2: value])
+)
+
+function onSelectedUpdateHandler(els) {
+  els.forEach(assignLabel)
 }

--- a/app/features/flex.js
+++ b/app/features/flex.js
@@ -52,17 +52,13 @@ export function Flex(visbug) {
   }
 }
 
-export const ensureFlex = (el) => el.style.display = 'flex'
-export const assignLabel = (el) => $(el).attr('data-label', `display: ${getComputedStyle(el).display}`)
-
-const ensureFlexAndAssignLabel = callback => (els, ...args) => {
-  els.forEach(el => { 
-    ensureFlex(el)
-    assignLabel(el)
-  })
-
-  return callback(els, ...args)
+const ensureFlex = el => {
+  el.style.display = 'flex'
+  return el
 }
+
+export const assignLabel = (el) => $(el).attr('data-label', `display: ${getComputedStyle(el).display}`)
+export const onSelectedUpdateHandler = (els) => els.forEach(assignLabel)
 
 const accountForOtherJustifyContent = (cur, want) => {
   if (want == 'align' && (cur != 'flex-start' && cur != 'center' && cur != 'flex-end'))
@@ -74,98 +70,103 @@ const accountForOtherJustifyContent = (cur, want) => {
 }
 
 // todo: support reversing direction
-export const changeDirection = ensureFlexAndAssignLabel(
-  (els, value) => els.forEach(el => el.style.flexDirection = value)
-);
+export function changeDirection(els, value) {
+  els
+    .map(ensureFlex)
+    .map(assignLabel)
+    .map(el => {
+      el.style.flexDirection = value
+    })
+}
 
 const h_alignMap      = {normal: 0,'flex-start': 0,'center': 1,'flex-end': 2,}
 const h_alignOptions  = ['flex-start','center','flex-end']
 
-export const changeHAlignment = ensureFlexAndAssignLabel(
-  (els, direction) => 
-    els
-      .map(el => ({
-        el,
-        style:    'justifyContent',
-        current:  accountForOtherJustifyContent(getStyle(el, 'justifyContent'), 'align'),
-        direction: direction.split('+').includes('left'),
+export function changeHAlignment(els, direction) {
+  els
+    .map(ensureFlex)
+    .map(assignLabel)
+    .map(el => ({
+      el,
+      style:    'justifyContent',
+      current:  accountForOtherJustifyContent(getStyle(el, 'justifyContent'), 'align'),
+      direction: direction.split('+').includes('left'),
+    }))
+    .map(payload =>
+      Object.assign(payload, {
+        value: payload.direction
+          ? h_alignMap[payload.current] - 1
+          : h_alignMap[payload.current] + 1
       }))
-      .map(payload =>
-        Object.assign(payload, {
-          value: payload.direction
-            ? h_alignMap[payload.current] - 1
-            : h_alignMap[payload.current] + 1
-        }))
-      .forEach(({el, style, value}) =>
-        el.style[style] = h_alignOptions[value < 0 ? 0 : value >= 2 ? 2: value])
-)
+    .forEach(({el, style, value}) =>
+      el.style[style] = h_alignOptions[value < 0 ? 0 : value >= 2 ? 2: value])
+}
 
 const v_alignMap      = {normal: 0,'flex-start': 0,'center': 1,'flex-end': 2,}
 const v_alignOptions  = ['flex-start','center','flex-end']
 
-export const changeVAlignment = ensureFlexAndAssignLabel(
-  (els, direction) => 
-    els
-      .map(el => ({
-        el,
-        style:    'alignItems',
-        current:  getStyle(el, 'alignItems'),
-        direction: direction.split('+').includes('up'),
+export function changeVAlignment(els, direction) {
+  els
+    .map(ensureFlex)
+    .map(assignLabel)
+    .map(el => ({
+      el,
+      style:    'alignItems',
+      current:  getStyle(el, 'alignItems'),
+      direction: direction.split('+').includes('up'),
+    }))
+    .map(payload =>
+      Object.assign(payload, {
+        value: payload.direction
+          ? h_alignMap[payload.current] - 1
+          : h_alignMap[payload.current] + 1
       }))
-      .map(payload =>
-        Object.assign(payload, {
-          value: payload.direction
-            ? h_alignMap[payload.current] - 1
-            : h_alignMap[payload.current] + 1
-        }))
-      .forEach(({el, style, value}) =>
-        el.style[style] = v_alignOptions[value < 0 ? 0 : value >= 2 ? 2: value])
-)
+    .forEach(({el, style, value}) =>
+      el.style[style] = v_alignOptions[value < 0 ? 0 : value >= 2 ? 2: value])
+}
 
 const h_distributionMap      = {normal: 1,'space-around': 0,'': 1,'space-between': 2,}
 const h_distributionOptions  = ['space-around','','space-between']
 
-export const changeHDistribution = ensureFlexAndAssignLabel(
-  (els, direction) => 
-    els
-      .map(el => ({
-        el,
-        style:    'justifyContent',
-        current:  accountForOtherJustifyContent(getStyle(el, 'justifyContent'), 'distribute'),
-        direction: direction.split('+').includes('left'),
+export function changeHDistribution(els, direction) {
+  els
+    .map(ensureFlex)
+    .map(assignLabel)
+    .map(el => ({
+      el,
+      style:    'justifyContent',
+      current:  accountForOtherJustifyContent(getStyle(el, 'justifyContent'), 'distribute'),
+      direction: direction.split('+').includes('left'),
+    }))
+    .map(payload =>
+      Object.assign(payload, {
+        value: payload.direction
+          ? h_distributionMap[payload.current] - 1
+          : h_distributionMap[payload.current] + 1
       }))
-      .map(payload =>
-        Object.assign(payload, {
-          value: payload.direction
-            ? h_distributionMap[payload.current] - 1
-            : h_distributionMap[payload.current] + 1
-        }))
-      .forEach(({el, style, value}) =>
-        el.style[style] = h_distributionOptions[value < 0 ? 0 : value >= 2 ? 2: value])
-)
+    .forEach(({el, style, value}) =>
+      el.style[style] = h_distributionOptions[value < 0 ? 0 : value >= 2 ? 2: value])
+}
 
 const v_distributionMap      = {normal: 1,'space-around': 0,'': 1,'space-between': 2,}
 const v_distributionOptions  = ['space-around','','space-between']
 
-export const changeVDistribution = ensureFlexAndAssignLabel(
-  (els, direction) =>
-    els
-      .map(el => ({
-        el,
-        style:    'alignContent',
-        current:  getStyle(el, 'alignContent'),
-        direction: direction.split('+').includes('up'),
+export function changeVDistribution(els, direction) {
+  els
+    .map(ensureFlex)
+    .map(assignLabel)
+    .map(el => ({
+      el,
+      style:    'alignContent',
+      current:  getStyle(el, 'alignContent'),
+      direction: direction.split('+').includes('up'),
+    }))
+    .map(payload =>
+      Object.assign(payload, {
+        value: payload.direction
+          ? v_distributionMap[payload.current] - 1
+          : v_distributionMap[payload.current] + 1
       }))
-      .map(payload =>
-        Object.assign(payload, {
-          value: payload.direction
-            ? v_distributionMap[payload.current] - 1
-            : v_distributionMap[payload.current] + 1
-        }))
-      .forEach(({el, style, value}) =>
-        el.style[style] = v_distributionOptions[value < 0 ? 0 : value >= 2 ? 2: value])
-)
-
-function onSelectedUpdateHandler(els) {
-  els.forEach(assignLabel)
+    .forEach(({el, style, value}) =>
+      el.style[style] = v_distributionOptions[value < 0 ? 0 : value >= 2 ? 2: value])
 }

--- a/app/features/flex.js
+++ b/app/features/flex.js
@@ -55,7 +55,7 @@ export function Flex(visbug) {
 export const ensureFlex = (el) => el.style.display = 'flex'
 export const assignLabel = (el) => $(el).attr('data-label', `display: ${getComputedStyle(el).display}`)
 
-const assignLabelAndEnsureFlex = callback => (els, ...args) => {
+const ensureFlexAndAssignLabel = callback => (els, ...args) => {
   els.forEach(el => { 
     ensureFlex(el)
     assignLabel(el)
@@ -74,14 +74,14 @@ const accountForOtherJustifyContent = (cur, want) => {
 }
 
 // todo: support reversing direction
-export const changeDirection = assignLabelAndEnsureFlex(
+export const changeDirection = ensureFlexAndAssignLabel(
   (els, value) => els.forEach(el => el.style.flexDirection = value)
 );
 
 const h_alignMap      = {normal: 0,'flex-start': 0,'center': 1,'flex-end': 2,}
 const h_alignOptions  = ['flex-start','center','flex-end']
 
-export const changeHAlignment = assignLabelAndEnsureFlex(
+export const changeHAlignment = ensureFlexAndAssignLabel(
   (els, direction) => 
     els
       .map(el => ({
@@ -103,7 +103,7 @@ export const changeHAlignment = assignLabelAndEnsureFlex(
 const v_alignMap      = {normal: 0,'flex-start': 0,'center': 1,'flex-end': 2,}
 const v_alignOptions  = ['flex-start','center','flex-end']
 
-export const changeVAlignment = assignLabelAndEnsureFlex(
+export const changeVAlignment = ensureFlexAndAssignLabel(
   (els, direction) => 
     els
       .map(el => ({
@@ -125,7 +125,7 @@ export const changeVAlignment = assignLabelAndEnsureFlex(
 const h_distributionMap      = {normal: 1,'space-around': 0,'': 1,'space-between': 2,}
 const h_distributionOptions  = ['space-around','','space-between']
 
-export const changeHDistribution = assignLabelAndEnsureFlex(
+export const changeHDistribution = ensureFlexAndAssignLabel(
   (els, direction) => 
     els
       .map(el => ({
@@ -147,7 +147,7 @@ export const changeHDistribution = assignLabelAndEnsureFlex(
 const v_distributionMap      = {normal: 1,'space-around': 0,'': 1,'space-between': 2,}
 const v_distributionOptions  = ['space-around','','space-between']
 
-export const changeVDistribution = assignLabelAndEnsureFlex(
+export const changeVDistribution = ensureFlexAndAssignLabel(
   (els, direction) =>
     els
       .map(el => ({

--- a/app/features/selectable.js
+++ b/app/features/selectable.js
@@ -418,14 +418,14 @@ export function Selectable(visbug) {
 
     clearHover()
 
+    selected.unshift(el)
+    tellWatchers()
+
     overlayMetaUI({
       el,
       id,
-      no_label: tool !== 'inspector' && tool !== 'accessibility',
+      no_label: !['inspector', 'accessibility', 'align'].includes(tool),
     })
-
-    selected.unshift(el)
-    tellWatchers()
   }
 
   const selection = () =>
@@ -439,6 +439,7 @@ export function Selectable(visbug) {
           'data-selected-hide': null,
           'data-label-id':      null,
           'data-pseudo-select': null,
+          'data-label':         null
         }))
 
     $('[data-pseudo-select]').forEach(hover =>
@@ -543,23 +544,25 @@ export function Selectable(visbug) {
   }
 
   const overlayMetaUI = ({el, id, no_label = true}) => {
+    let defaultTemplate = `
+      <a node>${el.nodeName.toLowerCase()}</a>
+      <a>${el.id && '#' + el.id}</a>
+      ${createClassname(el).split('.')
+        .filter(name => name != '')
+        .reduce((links, name) => `
+          ${links}
+          <a>.${name}</a>
+        `, '')
+      }
+    `;
+
     let handle = createHandle({el, id})
     let label  = no_label
       ? null
       : createLabel({
           el,
           id,
-          template: `
-            <a node>${el.nodeName.toLowerCase()}</a>
-            <a>${el.id && '#' + el.id}</a>
-            ${createClassname(el).split('.')
-              .filter(name => name != '')
-              .reduce((links, name) => `
-                ${links}
-                <a>.${name}</a>
-              `, '')
-            }
-          `
+          template: $(el).attr('data-label') || defaultTemplate
         })
 
     let observer        = createObserver(el, {handle,label})


### PR DESCRIPTION
Hi @argyleink!
Thank you for providing useful info regarding this story here: https://github.com/GoogleChromeLabs/ProjectVisBug/issues/36#issuecomment-520474082

Here's an implementation of container labels for Alignment Tool:
![Screen Shot 2019-08-14 at 11 23 03 AM](https://user-images.githubusercontent.com/9870032/63005816-f2815200-be85-11e9-85d8-baa9915ba30d.png)

### Reusable
Instead of displaying the label in [Flex component](https://github.com/GoogleChromeLabs/ProjectVisBug/blob/master/app/features/flex.js) tool I decided to reuse existing logic from [Selectable](https://github.com/GoogleChromeLabs/ProjectVisBug/blob/d38be5a82efb31e121e287647025caf53a6b05ac/app/features/selectable.js#L545) since it's already responsible for rendering the labels for other tools. 

### Inversion of control
Please also note how the control over the label content [is exposed to the Flex component](https://github.com/GoogleChromeLabs/ProjectVisBug/pull/374/files#diff-f1f22cd3d2f977263a1d06c53bf71a64R421) via `data-label` attribute and is set [here](https://github.com/GoogleChromeLabs/ProjectVisBug/pull/374/files#diff-88b451edc4b310ebe463e8febeb48b40R61). I believe this approach will allow other tools to define the custom label content for (selected/hovered) elements in a more flexible way. For that purpose, `tellWatchers` [needed to be invoked before drawing](https://github.com/GoogleChromeLabs/ProjectVisBug/pull/374/files#diff-f1f22cd3d2f977263a1d06c53bf71a64R421) `overlayMetaUI`.

### Functional approach
_(I'm a fan of Functional Programming and my opinion might be biased):_ I [refactored](https://github.com/GoogleChromeLabs/ProjectVisBug/pull/374/files#diff-88b451edc4b310ebe463e8febeb48b40R58) flex feature to `ensureFlex` and `assignLabel` on elements using a higher-order function to keep the code clean and fast (without adding another `.map` to the chain). But I'm afraid this coding style might conflict with overall coding style on the project, so let me know if there's a better way to accomplish the same. 

### Known issues / Limitations
While testing, I've noticed a case where the label content is not updated after `ensureFlex` is called. This happens because `overlayMetaUI` is only called on element select. Is this a known bug? It also happens when the user switches tools using hotkeys. I guess it could be resolved in a different story.
