### PR TITLE
Hoist local style modifications in the MetaTip

### DIFF
--- a/app/components/metatip/metatip.element.css
+++ b/app/components/metatip/metatip.element.css
@@ -118,7 +118,7 @@
   font-family: 'Dank Mono', 'Operator Mono', 'Inconsolata', 'Fira Mono', 'SF Mono', 'Monaco', 'Droid Sans Mono', 'Source Code Pro', monospace;
 }
 
-:host [value], 
+:host [value],
 :host [local-change] {
   color: var(--theme-text_color);
   display: inline-grid;
@@ -157,6 +157,10 @@
   margin-top: 1rem;
   color: var(--theme-color);
   font-weight: bold;
+
+  & + div {
+    margin-bottom: 1em;
+  }
 }
 
 :host [contrast] > span {

--- a/app/components/metatip/metatip.element.js
+++ b/app/components/metatip/metatip.element.js
@@ -68,12 +68,6 @@ export class Metatip extends HTMLElement {
           <span divider>×</span>
           <span>${Math.round(height)}</span>px
         </small>
-        <div>${notLocalModifications.reduce((items, item) => `
-          ${items}
-          <span prop>${item.prop}:</span>
-          <span value>${item.value}</span>
-        `, '')}
-        </div>
         ${localModifications.length ? `
           <h6 local-modifications>Local Modifications</h6>
           <div>${localModifications.reduce((items, item) => `
@@ -83,6 +77,12 @@ export class Metatip extends HTMLElement {
           `, '')}
           </div>
         ` : ''}
+        <div>${notLocalModifications.reduce((items, item) => `
+          ${items}
+          <span prop>${item.prop}:</span>
+          <span value>${item.value}</span>
+        `, '')}
+        </div>
       </figure>
     `
   }


### PR DESCRIPTION
Resolve #311 

## Description

I've changed DOM structure of `metatip.element.js` and related CSS styles for a bit.
It should be looked like this.

<img width="299" alt="Screen Shot 2019-08-26 at 22 22 10" src="https://user-images.githubusercontent.com/14539203/63694072-94267d00-c850-11e9-8c6b-cc5640fa0147.png">

## Consideration

I wonder whether the user can distinguish between local style modifications and computed styles easily.