### PR TITLE
🔥 Performance improvements

### DIFF
--- a/app/components/selection/handles.element.js
+++ b/app/components/selection/handles.element.js
@@ -33,7 +33,7 @@ export class Handles extends HTMLElement {
   }
 
   set position({el, node_label_id}) {
-    this.$shadow.innerHTML = this.render(el.getBoundingClientRect(), node_label_id)
+    this.$shadow.innerHTML = this.render(el['vis-box'], node_label_id)
 
     if (this._backdrop) {
       this.backdrop = {

--- a/app/components/selection/label.element.js
+++ b/app/components/selection/label.element.js
@@ -28,7 +28,7 @@ export class Label extends HTMLElement {
 
       this.position = {
         node_label_id,
-        boundingRect: source_el.getBoundingClientRect(),
+        boundingRect: source_el['vis-box'],
       }
     })
   }

--- a/app/features/guides.js
+++ b/app/features/guides.js
@@ -1,5 +1,5 @@
 import $ from 'blingblingjs'
-import { isOffBounds, deepElementFromPoint } from '../utilities/'
+import { isOffBounds, deepElementFromPoint, setVisbox } from '../utilities/'
 import { clearMeasurements, takeMeasurementOwnership } from './measurements'
 
 const state = {
@@ -30,9 +30,10 @@ export function Guides(visbug) {
   }
 }
 
-const on_hover = e => {
+const on_hover = async e => {
   const target = deepElementFromPoint(e.clientX, e.clientY)
   if (isOffBounds(target)) return
+  await setVisbox([target])
   showGridlines(target)
 }
 
@@ -91,11 +92,11 @@ const on_hoverout = () =>
 const showGridlines = node => {
   if (state.gridlines) {
     state.gridlines.style.display = null
-    state.gridlines.update = node.getBoundingClientRect()
+    state.gridlines.update = node['vis-box']
   }
   else {
     state.gridlines = document.createElement('visbug-gridlines')
-    state.gridlines.position = node.getBoundingClientRect()
+    state.gridlines.position = node['vis-box']
 
     document.body.appendChild(state.gridlines)
   }

--- a/app/features/imageswap.js
+++ b/app/features/imageswap.js
@@ -178,7 +178,7 @@ const getPictureSourcesToUpdate = img =>
 const showOverlay = (node, i) => {
   if (!state.watching) return
 
-  const rect    = node.getBoundingClientRect()
+  const rect    = node['vis-box']
   const overlay = overlays[i]
 
   if (overlay) {

--- a/app/features/margin.js
+++ b/app/features/margin.js
@@ -89,7 +89,7 @@ function removeBackgrounds(els) {
 }
 
 export function createMarginVisual(el, hover = false) {
-  const bounds            = el.getBoundingClientRect()
+  const bounds            = el['vis-box']
   const styleOM           = el.computedStyleMap()
   const calculatedStyle   = getStyle(el, 'margin')
   const boxdisplay        = document.createElement('visbug-boxmodel')

--- a/app/features/measurements.js
+++ b/app/features/measurements.js
@@ -11,8 +11,8 @@ export function createMeasurements({$anchor, $target}) {
 
   if (state.distances.length) clearMeasurements()
 
-  const anchorBounds = $anchor.getBoundingClientRect()
-  const targetBounds = $target.getBoundingClientRect()
+  const anchorBounds = $anchor['vis-box']
+  const targetBounds = $target['vis-box']
 
   const measurements = []
 

--- a/app/features/metatip.js
+++ b/app/features/metatip.js
@@ -4,7 +4,7 @@ import { TinyColor } from '@ctrl/tinycolor'
 import { queryPage } from './search'
 import { getStyles, camelToDash, isOffBounds, 
          deepElementFromPoint, getShadowValues,
-         getTextShadowValues
+         getTextShadowValues, setVisbox
 } from '../utilities/'
 
 const state = {
@@ -35,7 +35,7 @@ export function MetaTip({select}) {
   }
 }
 
-const mouseMove = e => {
+const mouseMove = async e => {
   const target = deepElementFromPoint(e.clientX, e.clientY)
 
   if (isOffBounds(target) || target.nodeName === 'VISBUG-METATIP' || target.hasAttribute('data-metatip')) { // aka: mouse out
@@ -50,7 +50,7 @@ const mouseMove = e => {
   }
 
   toggleTargetCursor(e.altKey, target)
-
+  await setVisbox([target])
   showTip(target, e)
 }
 

--- a/app/features/metatip.js
+++ b/app/features/metatip.js
@@ -130,7 +130,7 @@ export function removeAll() {
 }
 
 const render = (el, tip = document.createElement('visbug-metatip')) => {
-  const { width, height } = el.getBoundingClientRect()
+  const { width, height } = el['vis-box']
   const colormode = $('vis-bug')[0].colorMode
 
   const styles = getStyles(el)

--- a/app/features/metatip.js
+++ b/app/features/metatip.js
@@ -238,19 +238,17 @@ const togglePinned = e => {
 const linkQueryClicked = ({detail:{ text, activator }}) => {
   if (!text) return
 
-  queryPage('[data-pseudo-select]', el =>
-    el.removeAttribute('data-pseudo-select'))
+  unPseudoQuery()
 
-  queryPage(text + ':not([data-selected])', el =>
+  queryPage(text + ':not([data-selected])', els =>
     activator === 'mouseenter'
-      ? el.setAttribute('data-pseudo-select', true)
-      : services.selectors.select(el))
+      ? $(els).attr('data-pseudo-select', true)
+      : services.selectors.select(els))
 }
 
-const linkQueryHoverOut = e => {
-  queryPage('[data-pseudo-select]', el =>
-    el.removeAttribute('data-pseudo-select'))
-}
+const unPseudoQuery = _ =>
+  queryPage('[data-pseudo-select]', els =>
+    $(els).attr('data-pseudo-select', null))
 
 const toggleTargetCursor = (key, target) =>
   key
@@ -259,13 +257,13 @@ const toggleTargetCursor = (key, target) =>
 
 const observe = ({tip, target}) => {
   $(tip).on('query', linkQueryClicked)
-  $(tip).on('unquery', linkQueryHoverOut)
+  $(tip).on('unquery', unPseudoQuery)
   $(target).on('DOMNodeRemoved', handleBlur)
 }
 
 const unobserve = ({tip, target}) => {
   $(tip).off('query', linkQueryClicked)
-  $(tip).off('unquery', linkQueryHoverOut)
+  $(tip).off('unquery', unPseudoQuery)
   $(target).off('DOMNodeRemoved', handleBlur)
 }
 

--- a/app/features/padding.js
+++ b/app/features/padding.js
@@ -89,7 +89,7 @@ function removeBackgrounds(els) {
 }
 
 export function createPaddingVisual(el, hover = false) {
-  const bounds            = el.getBoundingClientRect()
+  const bounds            = el['vis-box']
   const styleOM           = el.computedStyleMap()
   const calculatedStyle   = getStyle(el, 'padding')
   const boxdisplay        = document.createElement('visbug-boxmodel')

--- a/app/features/search.js
+++ b/app/features/search.js
@@ -91,12 +91,10 @@ export function queryPage(query, fn) {
   try {
     let matches = querySelectorAllDeep(query + notList)
     if (!matches.length) matches = querySelectorAllDeep(query)
+      
     else if (matches.length) {
-      if (fn) 
-        matches.forEach(el => 
-          fn(el))
-      else
-        SelectorEngine.select(matches)
+      if (fn) fn(matches)
+      else SelectorEngine.select(matches)
     }
   }
   catch (err) {}

--- a/app/features/search.js
+++ b/app/features/search.js
@@ -92,10 +92,8 @@ export function queryPage(query, fn) {
     let matches = querySelectorAllDeep(query + notList)
     if (!matches.length) matches = querySelectorAllDeep(query)
     if (matches.length) {
-      matches.forEach(el =>
-        fn
-          ? fn(el)
-          : SelectorEngine.select(el))
+      SelectorEngine.select(matches)
+      if (fn) matches.forEach(el => fn(el))
     }
   }
   catch (err) {}

--- a/app/features/search.js
+++ b/app/features/search.js
@@ -91,9 +91,12 @@ export function queryPage(query, fn) {
   try {
     let matches = querySelectorAllDeep(query + notList)
     if (!matches.length) matches = querySelectorAllDeep(query)
-    if (matches.length) {
-      SelectorEngine.select(matches)
-      if (fn) matches.forEach(el => fn(el))
+    else if (matches.length) {
+      if (fn) 
+        matches.forEach(el => 
+          fn(el))
+      else
+        SelectorEngine.select(matches)
     }
   }
   catch (err) {}

--- a/app/features/selectable.js
+++ b/app/features/selectable.js
@@ -411,23 +411,29 @@ export function Selectable(visbug) {
     }
   }
 
-  const select = async el => {
-    const id = handles.length
-    const tool = visbug.activeTool
-
-    el.setAttribute('data-selected', true)
-    el.setAttribute('data-label-id', id)
+  const select = async els => {
+    els = typeof els === 'object'
+      ? [els]
+      : els
 
     clearHover()
-    await setVisbox([el])
+    await setVisbox(els)
 
-    overlayMetaUI({
-      el,
-      id,
-      no_label: tool !== 'inspector' && tool !== 'accessibility',
+    els.forEach(el => {
+      const id = handles.length
+      const tool = visbug.activeTool
+
+      el.setAttribute('data-selected', true)
+      el.setAttribute('data-label-id', id)
+
+      overlayMetaUI({
+        el,
+        id,
+        no_label: tool !== 'inspector' && tool !== 'accessibility',
+      })
     })
 
-    selected.unshift(el)
+    selected = [...selected, ...els]
     tellWatchers()
   }
 

--- a/app/features/selectable.js
+++ b/app/features/selectable.js
@@ -616,20 +616,20 @@ export function Selectable(visbug) {
         if (!detail.text) return
         this.query_text = detail.text
 
-        queryPage('[data-pseudo-select]', el =>
-          el.removeAttribute('data-pseudo-select'))
+        queryPage('[data-pseudo-select]', els =>
+          $(els).attr('data-pseudo-select', null))
 
-        queryPage(this.query_text + ':not([data-selected])', el =>
+        queryPage(this.query_text + ':not([data-selected])', els =>
           detail.activator === 'mouseenter'
-            ? el.setAttribute('data-pseudo-select', true)
-            : select(el))
+            ? $(els).attr('data-pseudo-select', true)
+            : select(els))
       })
 
       $(label).on('mouseleave', e => {
         e.preventDefault()
         e.stopPropagation()
-        queryPage('[data-pseudo-select]', el =>
-          el.removeAttribute('data-pseudo-select'))
+        queryPage('[data-pseudo-select]', els =>
+          $(els).attr('data-pseudo-select', null))
       })
 
       labels[labels.length] = label

--- a/app/features/selectable.js
+++ b/app/features/selectable.js
@@ -16,7 +16,7 @@ import {
   metaKey, htmlStringToDom, createClassname, camelToDash,
   isOffBounds, getStyles, deepElementFromPoint, getShadowValues,
   isSelectorValid, findNearestChildElement, findNearestParentElement,
-  getTextShadowValues
+  getTextShadowValues, setVisbox
 } from '../utilities/'
 
 export function Selectable(visbug) {
@@ -376,7 +376,7 @@ export function Selectable(visbug) {
     })
   }
 
-  const on_hover = e => {
+  const on_hover = async e => {
     const $target = deepElementFromPoint(e.clientX, e.clientY)
     const tool = visbug.activeTool
 
@@ -384,6 +384,8 @@ export function Selectable(visbug) {
       clearMeasurements()
       return clearHover()
     }
+
+    await setVisbox([$target])
 
     overlayHoverUI({
       el: $target,
@@ -409,7 +411,7 @@ export function Selectable(visbug) {
     }
   }
 
-  const select = el => {
+  const select = async el => {
     const id = handles.length
     const tool = visbug.activeTool
 
@@ -419,6 +421,7 @@ export function Selectable(visbug) {
     clearHover()
 
     selected.unshift(el)
+    await setVisbox(selected)
     tellWatchers()
 
     overlayMetaUI({

--- a/app/features/selectable.js
+++ b/app/features/selectable.js
@@ -387,11 +387,17 @@ export function Selectable(visbug) {
 
     await setVisbox([$target])
 
+    const gui = document.createDocumentFragment()
     overlayHoverUI({
       el: $target,
       // no_hover: tool === 'guides',
       no_label: tool !== 'guides',
     })
+    
+    gui.append(hover_state.element)
+    gui.append(hover_state.label)
+
+    document.body.append(gui)
 
     if (tool === 'guides' && selected.length >= 1 && !selected.includes($target)) {
       $target.setAttribute('data-measuring', true)

--- a/app/features/selectable.js
+++ b/app/features/selectable.js
@@ -419,6 +419,7 @@ export function Selectable(visbug) {
     el.setAttribute('data-label-id', id)
 
     clearHover()
+    await setVisbox([el])
 
     overlayMetaUI({
       el,
@@ -426,7 +427,6 @@ export function Selectable(visbug) {
       no_label: tool !== 'inspector' && tool !== 'accessibility',
     })
 
-    await setVisbox([el])
     selected.unshift(el)
     tellWatchers()
   }
@@ -578,7 +578,7 @@ export function Selectable(visbug) {
   }
 
   const setLabel = (el, label) =>
-    label.update = el.getBoundingClientRect()
+    label.update = el['vis-box']
 
   const createLabel = ({el, id, template}) => {
     if (!labels[id]) {
@@ -586,7 +586,7 @@ export function Selectable(visbug) {
 
       label.text = template
       label.position = {
-        boundingRect:   el.getBoundingClientRect(),
+        boundingRect:   el['vis-box'],
         node_label_id:  id,
       }
 
@@ -654,7 +654,7 @@ export function Selectable(visbug) {
 
       hover_state.label.text = text
       hover_state.label.position = {
-        boundingRect:   el.getBoundingClientRect(),
+        boundingRect:   el['vis-box'],
         node_label_id:  'hover',
       }
 

--- a/app/utilities/styles.js
+++ b/app/utilities/styles.js
@@ -58,6 +58,24 @@ export const getStyles = el => {
   })
 }
 
+export const setVisbox = els => {
+  return new Promise(resolve => {
+    const observer = new IntersectionObserver(entries => {
+      observer.disconnect()
+
+      for (const entry of entries) {
+        const el = els.find(el => el === entry.target)
+        el['vis-box'] = entry.boundingClientRect  
+      }
+      
+      resolve(els)
+    })
+
+    for (const el of els)
+      observer.observe(el)  
+  })
+}
+
 export const getComputedBackgroundColor = el => {
   let background = getStyle(el, 'background-color')
 


### PR DESCRIPTION
over time the selection and gui creation mechanisms's responsibilities were spread out. they've been unified where appropriate, resulting in multi-select, search queries, or anything that creates alot of gui, being 50% or 100% faster. Extreme cases are 80 nodes drawing their gui at 30ms or so, vs 80 nodes at 100ms

try it:
https://visbug-perf.glitch.me

**changes**:
- bulk and async getBoundingClientRect
- single document.body incision for appending visbug gui

fixes #112 
fixes #225 
fixes #160 

<br>

#### before
![Screen Shot 2019-09-04 at 10 50 29 PM](https://user-images.githubusercontent.com/1134620/64315301-8070ca00-cf66-11e9-85a4-3d9b0ad8945a.png)

#### after
![Screen Shot 2019-09-04 at 10 49 49 PM](https://user-images.githubusercontent.com/1134620/64315297-7cdd4300-cf66-11e9-87ec-0e0906647461.png)