### PR TITLE
Allow Align Tool change order and wrap (#370)

### DIFF
--- a/app/components/hotkey-map/align.element.js
+++ b/app/components/hotkey-map/align.element.js
@@ -19,6 +19,7 @@ export class AlignHotkeys extends HotkeyMap {
     this._side         = 'top left'
     this._direction    = 'row'
     this._distribution = distOptions[this._dtool]
+    this._wrap         = 'nowrap'
 
     this.tool     = 'align'
   }
@@ -27,9 +28,17 @@ export class AlignHotkeys extends HotkeyMap {
     let amount            = this._distribution
       , negative_modifier = this._direction
       , side              = this._side
-      , negative
+      , negative          = this._wrap
 
-    if (hotkeys.cmd && (code === 'ArrowRight' || code === 'ArrowDown')) {
+    if (hotkeys[metaKey] && hotkeys.shift) {
+      if (code === 'ArrowUp')
+        negative = 'nowrap'
+      else if (code === 'ArrowDown')
+        negative = 'wrap'
+      else if (code === 'ArrowLeft')
+        negative_modifier = `${negative_modifier}-reverse`
+    }
+    else if (hotkeys[metaKey] && (code === 'ArrowRight' || code === 'ArrowDown')) {
       negative_modifier = code === 'ArrowDown'
         ? 'column'
         : 'row'
@@ -57,7 +66,7 @@ export class AlignHotkeys extends HotkeyMap {
     }
   }
 
-  displayCommand({side, amount, negative_modifier}) {
+  displayCommand({side, amount, negative, negative_modifier}) {
     if (amount == 1) amount = this._distribution
     if (negative_modifier == ' to ') negative_modifier = this._direction
 
@@ -68,6 +77,7 @@ export class AlignHotkeys extends HotkeyMap {
       <span side>${side}</span>
       <span light> distributed </span>
       <span amount>${amount}</span>
+      <span amount>${negative}</span>
     `
   }
 

--- a/app/components/hotkey-map/align.element.js
+++ b/app/components/hotkey-map/align.element.js
@@ -32,7 +32,7 @@ export class AlignHotkeys extends HotkeyMap {
 
     if (hotkeys[metaKey] && hotkeys.shift) {
       if (code === 'ArrowUp')
-        negative = 'nowrap'
+        negative = 'no wrap'
       else if (code === 'ArrowDown')
         negative = 'wrap'
       else if (code === 'ArrowLeft')

--- a/app/components/hotkey-map/align.element.js
+++ b/app/components/hotkey-map/align.element.js
@@ -75,9 +75,10 @@ export class AlignHotkeys extends HotkeyMap {
       <span light> as </span>
       <span>${negative_modifier}:</span>
       <span side>${side}</span>
-      <span light> distributed </span>
-      <span amount>${amount}</span>
-      <span amount>${negative}</span>
+      <span light>, distributed </span>
+      <span amount>${amount},</span>
+      <span light> with </span>
+      <span>${negative}</span>
     `
   }
 

--- a/app/components/hotkey-map/align.element.js
+++ b/app/components/hotkey-map/align.element.js
@@ -19,7 +19,7 @@ export class AlignHotkeys extends HotkeyMap {
     this._side         = 'top left'
     this._direction    = 'row'
     this._distribution = distOptions[this._dtool]
-    this._wrap         = 'nowrap'
+    this._wrap         = 'no wrap'
 
     this.tool     = 'align'
   }

--- a/app/components/vis-bug/model.js
+++ b/app/components/vis-bug/model.js
@@ -138,7 +138,7 @@ export const VisBugModel = {
     tool:        'align',
     icon:        Icons.align,
     label:       'Flexbox Align',
-    description: `Create or modify flexbox direction, distribution & alignment`,
+    description: `Create or modify flexbox direction, distribution, alignment & wrapping`,
     instruction: `<div table>
                     <div>
                       <b>Rows:</b>
@@ -155,6 +155,14 @@ export const VisBugModel = {
                     <div>
                       <b>Distribution:</b>
                       <span>Shift + ◀ ▶</span>
+                    </div>
+                    <div>
+                      <b>Order:</b>
+                      <span>${metaKey} + shift + ◀ ▶</span>
+                    </div>
+                    <div>
+                      <b>Wrapping:</b>
+                      <span>${metaKey} + shift + ▲ ▼</span>
                     </div>
                     <div>
                       <b>Trainer:</b>

--- a/app/components/vis-bug/model.js
+++ b/app/components/vis-bug/model.js
@@ -138,7 +138,7 @@ export const VisBugModel = {
     tool:        'align',
     icon:        Icons.align,
     label:       'Flexbox Align',
-    description: `Create or modify flexbox direction, distribution, alignment & wrapping`,
+    description: `Create or modify flexbox direction, distribution, order & wrapping`,
     instruction: `<div table>
                     <div>
                       <b>Rows:</b>

--- a/app/features/flex.test.js
+++ b/app/features/flex.test.js
@@ -92,6 +92,81 @@ test('Can apply space-between', async t => {
   t.pass()
 })
 
+test('Can adjust wrapping', async t => {
+  const { page } = t.context
+
+  await page.click(test_selector)
+  await page.keyboard.down('Control')
+  await page.keyboard.down('Shift')
+  await page.keyboard.press('ArrowUp')
+  let wrapStr = await page.$eval(test_selector, el => el.style.flexWrap)
+  t.true(wrapStr === 'nowrap')
+
+  await page.keyboard.press('ArrowUp')
+  wrapStr = await page.$eval(test_selector, el => el.style.flexWrap)
+  t.true(wrapStr === 'nowrap')
+
+  await page.keyboard.press('ArrowDown')
+  wrapStr = await page.$eval(test_selector, el => el.style.flexWrap)
+  t.true(wrapStr === 'wrap')
+
+  await page.keyboard.press('ArrowDown')
+  wrapStr = await page.$eval(test_selector, el => el.style.flexWrap)
+  t.true(wrapStr === 'wrap')
+
+  t.pass()
+})
+
+test('Can adjust row order', async t => {
+  const { page } = t.context
+
+  await page.click(test_selector)
+  await page.keyboard.down('Control')
+  await page.keyboard.down('Shift')
+  await page.keyboard.press('ArrowLeft')
+  let dirStr = await page.$eval(test_selector, el => el.style.flexDirection)
+  t.true(dirStr === 'row-reverse')
+
+  await page.keyboard.press('ArrowLeft')
+  dirStr = await page.$eval(test_selector, el => el.style.flexDirection)
+  t.true(dirStr === 'row-reverse')
+
+  await page.keyboard.press('ArrowRight')
+  dirStr = await page.$eval(test_selector, el => el.style.flexDirection)
+  t.true(dirStr === 'row')
+
+  await page.keyboard.press('ArrowRight')
+  dirStr = await page.$eval(test_selector, el => el.style.flexDirection)
+  t.true(dirStr === 'row')
+
+  t.pass()
+})
+
+test('Can adjust column order', async t => {
+  const { page } = t.context
+
+  await page.click(test_selector)
+  await page.keyboard.down('Control')
+  await page.keyboard.press('ArrowUp')
+  await page.keyboard.down('Shift')
+  await page.keyboard.press('ArrowLeft')
+  let dirStr = await page.$eval(test_selector, el => el.style.flexDirection)
+  t.true(dirStr === 'column-reverse')
+
+  await page.keyboard.press('ArrowLeft')
+  dirStr = await page.$eval(test_selector, el => el.style.flexDirection)
+  t.true(dirStr === 'column-reverse')
+
+  await page.keyboard.press('ArrowRight')
+  dirStr = await page.$eval(test_selector, el => el.style.flexDirection)
+  t.true(dirStr === 'column')
+
+  await page.keyboard.press('ArrowRight')
+  dirStr = await page.$eval(test_selector, el => el.style.flexDirection)
+  t.true(dirStr === 'column')
+
+  t.pass()
+})
 
 
 test.afterEach(teardownPptrTab)


### PR DESCRIPTION
Allow Align Tool change flex-direction and flex-wrap (#370):
- listen for hotkeys
    - cmd+shift+up: nowrap
    - cmd+shift+down: wrap
    - cmd+shift+left: row-reverse / column-reverse
    - cmd+shift+right: row / column
- update tool instruction card
- update tool trainer
- test adjusting flex-direction and flex-wrap