### PR TITLE
add execCommand call

### DIFF
--- a/app/components/vis-bug/vis-bug.element.js
+++ b/app/components/vis-bug/vis-bug.element.js
@@ -17,6 +17,7 @@ import { VisBugModel }            from './model'
 import * as Icons                 from './vis-bug.icons'
 import { provideSelectorEngine }  from '../../features/search'
 import { metaKey }                from '../../utilities/'
+import { PluginRegistry }         from '../../plugins/_registry'
 
 const modemap = {
   'hex':  'toHexString',
@@ -228,6 +229,18 @@ export default class VisBug extends HTMLElement {
       this.selectorEngine.removeSelectedCallback(feature.onNodesSelected)
       feature.disconnect()
     }
+  }
+
+  execCommand(command) {
+    const query = `/${command}`;
+
+    if (PluginRegistry.has(query))
+      return PluginRegistry.get(query)({
+        selected: this.selectorEngine.selection(),
+        query
+      })
+
+    return Promise.resolve(new Error("Query not found"))
   }
 
   get activeTool() {

--- a/app/components/vis-bug/vis-bug.element.js
+++ b/app/components/vis-bug/vis-bug.element.js
@@ -232,7 +232,7 @@ export default class VisBug extends HTMLElement {
   }
 
   execCommand(command) {
-    const query = `/${command}`;
+    const query = `/${command}`
 
     if (PluginRegistry.has(query))
       return PluginRegistry.get(query)({

--- a/app/components/vis-bug/vis-bug.test.js
+++ b/app/components/vis-bug/vis-bug.test.js
@@ -1,6 +1,6 @@
 import test from 'ava'
 
-import { setupPptrTab, teardownPptrTab, getActiveTool } 
+import { setupPptrTab, teardownPptrTab, getActiveTool }
 from '../../../tests/helpers'
 
 test.beforeEach(setupPptrTab)
@@ -87,6 +87,23 @@ test('Should be hideable', async t => {
   const visibility = await page.evaluate(`document.querySelector('vis-bug').$shadow.host.style.display`)
 
   t.pass(visibility, 'none')
+  t.pass()
+})
+
+test('Should accept valid execCommand', async t => {
+  const { page } = t.context
+  const execCommand = await page.evaluate(`document.querySelector('vis-bug').execCommand('pesticide')`)
+
+
+  t.is(execCommand, undefined)
+  t.pass()
+})
+
+test('Should throw on invalid execCommand', async t => {
+  const { page } = t.context
+  const execCommand = await page.evaluate(`document.querySelector('vis-bug').execCommand('invalid command')`)
+
+  t.deepEqual(execCommand, {})
   t.pass()
 })
 


### PR DESCRIPTION
This adds an execCommand function to the vis-bug instance that can be used to call any of the plugin commands:

```js
document.querySelector('vis-bug').execCommand('pesticide');
```
It will return the promise just like the search query does, and if it does not find a matching command, it returns a promise that resolves to an error.

**Tests**

There's two tests, checking an invalid case and a valid case. I think I need input on them because i'm not sure how ava + puppeteer handle promises. A valid `pesticide` command resolves to undefined, which is fine, but the invalid I expect to resolve to an Error, but it resolves to `{}`.

**Bikeshedding**
execCommand might not be the best name, Other options:

* executeCommand
* command
* execCmd
* call

**Stretch goals**
Right now this function only handles the registered plugin commands, but could probably also just call the `queryPage` function from `features/search.js` and be equivalent to the search. The nice thing now is that the `/` in front of a command isn't needed, if we use the queryPage function then any plugin commands need to be prefixed with it. 
