### PR TITLE
Adds z-index visualization plugin

### DIFF
--- a/app/plugins/_dynamic-registery.js
+++ b/app/plugins/_dynamic-registery.js
@@ -4,6 +4,7 @@ const entries = [
   'pesticide.js',
   'construct.js',
   'construct.debug.js',
+  'zindex.js',
 ]
 
 const PluginRegistry = new Map()

--- a/app/plugins/_registry.js
+++ b/app/plugins/_registry.js
@@ -10,11 +10,12 @@ import { commands as revenge_commands, default as RevengePlugin } from './reveng
 import { commands as tota11y_commands, default as Tota11yPlugin } from './tota11y'
 import { commands as shuffle_commands, default as ShufflePlugin } from './shuffle'
 import { commands as colorblind_commands, default as ColorblindPlugin } from './colorblind'
+import { commands as zindex_commands, default as ZIndexPlugin } from './zindex'
 
 const commandsToHash = (plugin_commands, plugin_fn) =>
   plugin_commands.reduce((commands, command) =>
-    Object.assign(commands, {[`/${command}`]:plugin_fn})
-  , {})
+    Object.assign(commands, { [`/${command}`]: plugin_fn })
+    , {})
 
 export const PluginRegistry = new Map(Object.entries({
   ...commandsToHash(blank_page_commands, BlankPagePlugin),
@@ -29,6 +30,7 @@ export const PluginRegistry = new Map(Object.entries({
   ...commandsToHash(tota11y_commands, Tota11yPlugin),
   ...commandsToHash(shuffle_commands, ShufflePlugin),
   ...commandsToHash(colorblind_commands, ColorblindPlugin),
+  ...commandsToHash(zindex_commands, ZIndexPlugin),
 }))
 
 export const PluginHints = [
@@ -43,5 +45,6 @@ export const PluginHints = [
   revenge_commands[0],
   tota11y_commands[0],
   shuffle_commands[0],
+  zindex_commands[0],
   ...colorblind_commands,
 ].map(command => `/${command}`)

--- a/app/plugins/blank-page.js
+++ b/app/plugins/blank-page.js
@@ -4,7 +4,7 @@ export const commands = [
   'clear canvas',
 ]
 
-export default function() {
+export default function () {
   document
     .querySelectorAll('body > *:not(vis-bug):not(script)')
     .forEach(node => node.remove())

--- a/app/plugins/zindex.js
+++ b/app/plugins/zindex.js
@@ -1,0 +1,31 @@
+export const commands = [
+    'zindex',
+    'z-index',
+    'show z-index',
+]
+
+export default function () {
+    // Fun prior art https://gist.github.com/paulirish/211209
+    const all = document.querySelectorAll('*')
+    const filtered = Array.from(all).filter(el => window.getComputedStyle(el).getPropertyValue('z-index') !== 'auto')
+
+    filtered.forEach(el => {
+        // Why 16777215? https://dev.to/akhil_001/generating-random-color-with-single-line-of-js-code-fhj
+        let color = `#${Math.floor(Math.random() * 16777215).toString(16)}`
+        let position = window.getComputedStyle(el).getPropertyValue('position')
+
+        if (position === 'absolute' || position === 'relative') {
+            el.style.position === 'relative'
+        }
+
+        el.style.outline = `1px solid ${color}`
+
+        let overlay = document.createElement('span')
+        let zindex = window.getComputedStyle(el).getPropertyValue('z-index')
+        let contrast = '#' +
+            (Number('0x' + color.substr(1)).toString(10) > 0xffffff / 2 ? '000000' : 'ffffff')
+        overlay.textContent = `z-index: ${zindex}`
+        overlay.style.cssText = `background: ${color}; color: ${contrast}; position: 'absolute'; top: 0; left: 0; textIndent: 0;`
+        el.appendChild(overlay)
+    })
+}

--- a/app/plugins/zindex.js
+++ b/app/plugins/zindex.js
@@ -1,31 +1,30 @@
 export const commands = [
     'zindex',
-    'z-index',
-    'show z-index',
+    'z-index'
 ]
 
 export default function () {
     // Fun prior art https://gist.github.com/paulirish/211209
-    const all = document.querySelectorAll('*')
-    const filtered = Array.from(all).filter(el => window.getComputedStyle(el).getPropertyValue('z-index') !== 'auto')
+    Array.from(document.querySelectorAll('*'))
+        .filter(el => el.computedStyleMap().get('z-index').value !== 'auto')
+        .filter(el => el.nodeName !== 'VIS-BUG')
+        .forEach(el => {
+            const color = `#${Math.floor(Math.random() * 16777215).toString(16)}`
+            const zindex = el.computedStyleMap().get('z-index').value
 
-    filtered.forEach(el => {
-        // Why 16777215? https://dev.to/akhil_001/generating-random-color-with-single-line-of-js-code-fhj
-        let color = `#${Math.floor(Math.random() * 16777215).toString(16)}`
-        let position = window.getComputedStyle(el).getPropertyValue('position')
+            const label = document.createElement('visbug-label')
 
-        if (position === 'absolute' || position === 'relative') {
-            el.style.position === 'relative'
-        }
+            label.text = `z-index: ${zindex}`
+            label.position = {
+                boundingRect: el.getBoundingClientRect()
+            }
+            label.style.setProperty(`--label-bg`, color)
 
-        el.style.outline = `1px solid ${color}`
+            const overlay = document.createElement('visbug-hover')
+            overlay.position = { el }
+            overlay.style.setProperty(`--hover-stroke`, color)
 
-        let overlay = document.createElement('span')
-        let zindex = window.getComputedStyle(el).getPropertyValue('z-index')
-        let contrast = '#' +
-            (Number('0x' + color.substr(1)).toString(10) > 0xffffff / 2 ? '000000' : 'ffffff')
-        overlay.textContent = `z-index: ${zindex}`
-        overlay.style.cssText = `background: ${color}; color: ${contrast}; position: 'absolute'; top: 0; left: 0; textIndent: 0;`
-        el.appendChild(overlay)
-    })
+            document.body.appendChild(label)
+            document.body.appendChild(overlay)
+        })
 }


### PR DESCRIPTION
This change introduces a `z-index` visualization plugin. The idea is to render a box with the `z-index` value for each child, to help developers debug index stacking. Each box is given a random color to help distinguish what you're seeing.

Below you can see the plugin being used on a few sites:

<img width="1277" alt="Screen Shot 2019-12-12 at 12 26 33 PM" src="https://user-images.githubusercontent.com/110953/70747074-07f37500-1cdc-11ea-80f2-781dc565a9a6.png">

![image](https://user-images.githubusercontent.com/110953/70747468-ecd53500-1cdc-11ea-855e-f1590c66de39.png)

<img width="1280" alt="Screen Shot 2019-12-12 at 12 27 09 PM" src="https://user-images.githubusercontent.com/110953/70747088-12ae0a00-1cdc-11ea-85ef-b204bb3df0fd.png">

Very open to additional commits being added by @argyleink to improve this. A few areas it could be improved:

Feel free to let me know if this isn't a great fit for this project :)

* Command-name: I added `zindex` and `z-index`, however if there's something better, please feel free to change it
* Visualization: I'm aware of 3D DOM viz work being explored by some DevTools teams right now, but still like the simplicity this visualization offers :) I'm sure this could be improved. Potentially tweaking font-size, the model for setting colors or logic for how to determine what to visualize. 
* Bugs: On pages heavily using `z-index` you can end up with boxes which overlap. One could argue an MVP doesn't need to tackle this, but it's definitely visible sometimes. It could be fixed with a model for avoiding overlapping positions of what is drawn.

This work is inspired by a bookmarklet Mr. @paulirish wrote 10 years ago :) 

[Original gist](https://gist.github.com/paulirish/211209)
[Non-jQuery rewrite this is based on](https://gist.github.com/addyosmani/5dfbc458e8446b1f2c15042d374bb830)