### PR TITLE
Make sure a valid color is always returned for z-index plugin

### DIFF
--- a/app/plugins/zindex.js
+++ b/app/plugins/zindex.js
@@ -9,7 +9,7 @@ export default function () {
         .filter(el => el.computedStyleMap().get('z-index').value !== 'auto')
         .filter(el => el.nodeName !== 'VIS-BUG')
         .forEach(el => {
-            const color = `#${Math.floor(Math.random() * 16777215).toString(16)}`
+            const color = `#${Math.floor(Math.random() * 16777215).toString(16).padStart(6,0)}`
             const zindex = el.computedStyleMap().get('z-index').value
 
             const label = document.createElement('visbug-label')


### PR DESCRIPTION
The color function in the z-index plugin sometimes returns less than 6 characters, resulting in an invalid color. This pads the string with leading 0's if needed, making the color always valid.