### PR TITLE
Metatip style update

### DIFF
--- a/app/components/_variables.css
+++ b/app/components/_variables.css
@@ -41,4 +41,9 @@
     --theme-bd-opacity: .8;
     --theme-bd-2-opacity: .9;
   }
+
+  @supports (-webkit-backdrop-filter: blur(5px)) {
+    --theme-bd-opacity: .8;
+    --theme-bd-2-opacity: .9;
+  }
 }

--- a/app/components/_variables.css
+++ b/app/components/_variables.css
@@ -24,7 +24,7 @@
     --theme-bg: hsl(0 0% 10%);
     --theme-bd: hsl(0 0% 10% / var(--theme-bd-opacity));
     --theme-bd-2: hsl(0 0% 10% / var(--theme-bd-2-opacity));
-
+    --theme-color: hsl(330deg 65% 75%);
     --theme-text_color: hsl(0 0% 90%);
     --theme-icon_color: hsl(0 0% 80%);
     --theme-icon_hover-bg: hsl(0 0% 15%);

--- a/app/components/_variables.css
+++ b/app/components/_variables.css
@@ -20,6 +20,12 @@
   --layer-4: 2147483643;
   --layer-5: 2147483642;
 
+  --text-shadow: 0 1px hsl(0 0% 0% / 40%);
+
+  @media (-webkit-min-device-pixel-ratio: 2) {
+    --text-shadow: 0 .5px hsl(0 0% 0% / 50%);
+  }
+
   @media (prefers-color-scheme: dark) {
     --theme-bg: hsl(0 0% 10%);
     --theme-bd: hsl(0 0% 10% / var(--theme-bd-opacity));

--- a/app/components/metatip/ally.element.js
+++ b/app/components/metatip/ally.element.js
@@ -8,15 +8,17 @@ export class Ally extends Metatip {
   render({el, ally_attributes, contrast_results}) {
     return `
       <figure>
-        <h5>${el.nodeName.toLowerCase()}${el.id && '#' + el.id}</h5>
-        <div accessibility>
+        <header>
+          <h5>${el.nodeName.toLowerCase()}${el.id && '#' + el.id}</h5>
+        </header>
+        <code accessibility>
           ${ally_attributes.reduce((items, attr) => `
             ${items}
             <span prop>${attr.prop}:</span>
             <span value>${attr.value}</span>
           `, '')}
           ${contrast_results}
-        </div>
+        </code>
       </figure>
     `
   }

--- a/app/components/metatip/metatip.element.css
+++ b/app/components/metatip/metatip.element.css
@@ -85,6 +85,7 @@
   margin: 0;
   overflow: hidden;
   white-space: nowrap;
+  max-width: max-content;
 }
 
 :host h6 {
@@ -116,6 +117,7 @@
 
 :host header {
   padding: 5px 10px;
+  user-select: none;
 }
 
 :host code {

--- a/app/components/metatip/metatip.element.css
+++ b/app/components/metatip/metatip.element.css
@@ -26,6 +26,7 @@
   max-width: 50vw;
   background: var(--theme-bd);
   backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
   color: var(--theme-text_color);
   line-height: initial;
   margin: 0;

--- a/app/components/metatip/metatip.element.css
+++ b/app/components/metatip/metatip.element.css
@@ -30,7 +30,7 @@
   display: flex;
   flex-direction: column;
   flex-wrap: nowrap;
-  border-radius: 0.25em;
+  border-radius: 1em;
   line-height: initial;
 
   box-shadow:
@@ -123,6 +123,7 @@
   grid-template-columns: auto auto;
   gap: .25em .5em;
   padding: 10px;
+  border-radius: inherit;
   list-style-type: none;
   color: var(--theme-text_color);
   background-color: var(--theme-bd-2);

--- a/app/components/metatip/metatip.element.css
+++ b/app/components/metatip/metatip.element.css
@@ -14,6 +14,8 @@
   --arrow-up: polygon(0 0, 100% 0, 50% 100%);
   --arrow-down: polygon(50% 0, 0 100%, 100% 100%);
   --arrow: var(--arrow-up);
+
+  --border-radius: .75em;
 }
 
 :host figure {
@@ -30,7 +32,7 @@
   display: flex;
   flex-direction: column;
   flex-wrap: nowrap;
-  border-radius: 1em;
+  border-radius: var(--border-radius);
   line-height: initial;
 
   box-shadow:
@@ -88,12 +90,6 @@
   max-width: max-content;
 }
 
-:host h6 {
-  margin-top: 1em;
-  margin-bottom: 0;
-  font-weight: normal;
-}
-
 :host small {
   font-size: 0.7em;
   color: var(--theme-icon_color);
@@ -124,14 +120,29 @@
   display: grid;
   grid-template-columns: auto auto;
   gap: .25em .5em;
-  padding: 10px;
-  border-radius: inherit;
+  border-radius: var(--border-radius);
   list-style-type: none;
-  color: var(--theme-text_color);
+  color: var(--light-grey);
   background-color: var(--theme-bd-2);
   border-top: 1px solid var(--theme-bg);
   font-size: 1em;
   font-family: 'Dank Mono', 'Operator Mono', 'Inconsolata', 'Fira Mono', 'SF Mono', 'Monaco', 'Droid Sans Mono', 'Source Code Pro', monospace;
+}
+
+:host details > :is(summary,code),
+:host > figure > code {
+  padding: 10px;
+  border-radius: var(--border-radius);
+}
+
+:host summary {
+  outline-offset: -2px;
+  outline-color: var(--theme-color);
+  max-inline-size: max-content;
+
+  &::marker {
+    color: var(--theme-color);
+  }
 }
 
 :host [value],
@@ -153,7 +164,7 @@
 :host [longform] {
   background: var(--theme-icon_hover-bg);
   padding: 0.5em 0.75em;
-  border-radius: 0.25em;
+  border-radius: .25em;
   font-family: sans-serif;
   text-align: left;
   line-height: 1.5;
@@ -171,11 +182,12 @@
   min-width: 1em;
   height: 1em;
   border-radius: 50%;
+  box-shadow: inset 0 0 1px 0 hsl(0 0% 0% / 50%);
 }
 
 :host [local-modifications] {
   margin-top: 1em;
-  margin-left: 10px;
+  margin-inline: 10px;
   color: var(--theme-purple);
   font-weight: bold;
 
@@ -186,7 +198,7 @@
 
 :host [contrast] > span {
   padding: 0 0.5em 0.1em;
-  border-radius: 1em;
+  border-radius: var(--border-radius);
   box-shadow: 0 0 0 1px var(--theme-icon_active-bg);
 }
 

--- a/app/components/metatip/metatip.element.css
+++ b/app/components/metatip/metatip.element.css
@@ -118,7 +118,7 @@
 
 :host code {
   display: grid;
-  grid-template-columns: auto auto;
+  grid-template-columns: max-content auto;
   gap: .25em .5em;
   border-radius: var(--border-radius);
   list-style-type: none;

--- a/app/components/metatip/metatip.element.css
+++ b/app/components/metatip/metatip.element.css
@@ -26,7 +26,6 @@
   backdrop-filter: blur(5px);
   color: var(--theme-text_color);
   line-height: initial;
-  padding: 0.5em;
   margin: 0;
   display: flex;
   flex-direction: column;
@@ -107,19 +106,26 @@
   text-decoration: none;
 }
 
-:host [brand],
-:host [divider] {
+:host [brand] {
   color: var(--theme-color);
 }
 
-:host div {
+:host [divider] {
+  color: var(--theme-purple);
+}
+
+:host header {
+  padding: 5px 10px;
+}
+
+:host code {
   display: grid;
   grid-template-columns: auto auto;
-  grid-gap: 0.25em 0.5em;
-  margin: 0.5em 0 0;
-  padding: .5em 0 0;
+  gap: .25em .5em;
+  padding: 10px;
   list-style-type: none;
   color: var(--theme-text_color);
+  background-color: var(--theme-bd-2);
   border-top: 1px solid var(--theme-bg);
   font-size: 1em;
   font-family: 'Dank Mono', 'Operator Mono', 'Inconsolata', 'Fira Mono', 'SF Mono', 'Monaco', 'Droid Sans Mono', 'Source Code Pro', monospace;
@@ -150,6 +156,10 @@
   line-height: 1.5;
 }
 
+:host [prop] {
+  color: var(--theme-color);
+}
+
 :host [color] {
   position: relative;
   top: 1px;
@@ -161,8 +171,9 @@
 }
 
 :host [local-modifications] {
-  margin-top: 1rem;
-  color: var(--theme-color);
+  margin-top: 1em;
+  margin-left: 10px;
+  color: var(--theme-purple);
   font-weight: bold;
 
   & + div {

--- a/app/components/metatip/metatip.element.css
+++ b/app/components/metatip/metatip.element.css
@@ -108,12 +108,13 @@
 }
 
 :host [divider] {
-  color: var(--theme-purple);
+  color: var(--theme-blue);
 }
 
 :host header {
   padding: 5px 10px;
   user-select: none;
+  text-shadow: var(--text-shadow);
 }
 
 :host code {

--- a/app/components/metatip/metatip.element.js
+++ b/app/components/metatip/metatip.element.js
@@ -72,7 +72,7 @@ export class Metatip extends HTMLElement {
         </header>
         <code>${notLocalModifications.reduce((items, item) => `
           ${items}
-          <span prop>${item.prop}:</span>
+          <span><span prop>${item.prop}</span>:</span>
           <span value>${item.value}</span>
         `, '')}
         </code>
@@ -80,7 +80,7 @@ export class Metatip extends HTMLElement {
           <h6 local-modifications>Local Modifications / Inline Styles</h6>
           <code>${localModifications.reduce((items, item) => `
             ${items}
-            <span prop>${item.prop}:</span>
+            <span><span prop>${item.prop}</span>:</span>
             <span value>${item.value}</span>
           `, '')}
           </code>

--- a/app/components/metatip/metatip.element.js
+++ b/app/components/metatip/metatip.element.js
@@ -78,6 +78,7 @@ export class Metatip extends HTMLElement {
             <span>${Math.round(height)}</span><span brand>px</span>
           </small>
         </header>
+
         <code>${notLocalModifications.reduce((items, item) => `
           ${items}
           <span><span prop>${item.prop}</span>:</span>
@@ -85,13 +86,15 @@ export class Metatip extends HTMLElement {
         `, '')}
         </code>
         ${localModifications.length ? `
-          <h6 local-modifications>Local Modifications / Inline Styles</h6>
-          <code>${localModifications.reduce((items, item) => `
-            ${items}
-            <span><span prop>${item.prop}</span>:</span>
-            <span value>${item.value}</span>
-          `, '')}
-          </code>
+          <details>
+            <summary>Local Modifications / Inline Styles</summary>
+            <code>${localModifications.reduce((items, item) => `
+              ${items}
+              <span><span prop>${item.prop}</span>:</span>
+              <span value>${item.value}</span>
+            `, '')}
+            </code>
+          </details>
         ` : ''}
       </figure>
     `

--- a/app/components/metatip/metatip.element.js
+++ b/app/components/metatip/metatip.element.js
@@ -52,37 +52,39 @@ export class Metatip extends HTMLElement {
   render({el, width, height, localModifications, notLocalModifications}) {
     return `
       <figure>
-        <h5>
-          <a node>${el.nodeName.toLowerCase()}</a>
-          <a>${el.id && '#' + el.id}</a>
-          ${createClassname(el).split('.')
-            .filter(name => name != '')
-            .reduce((links, name) => `
-              ${links}
-              <a>.${name}</a>
-            `, '')
-          }
-        </h5>
-        <small>
-          <span">${Math.round(width)}</span>px
-          <span divider>×</span>
-          <span>${Math.round(height)}</span>px
-        </small>
-        ${localModifications.length ? `
-          <h6 local-modifications>Local Modifications</h6>
-          <div>${localModifications.reduce((items, item) => `
-            ${items}
-            <span prop>${item.prop}:</span>
-            <span value>${item.value}</span>
-          `, '')}
-          </div>
-        ` : ''}
-        <div>${notLocalModifications.reduce((items, item) => `
+        <header>
+          <h5>
+            <a node>${el.nodeName.toLowerCase()}</a>
+            <a>${el.id && '#' + el.id}</a>
+            ${createClassname(el).split('.')
+              .filter(name => name != '')
+              .reduce((links, name) => `
+                ${links}
+                <a>.${name}</a>
+              `, '')
+            }
+          </h5>
+          <small>
+            <span">${Math.round(width)}</span><span brand>px</span>
+            <span divider>×</span>
+            <span>${Math.round(height)}</span><span brand>px</span>
+          </small>
+        </header>
+        <code>${notLocalModifications.reduce((items, item) => `
           ${items}
           <span prop>${item.prop}:</span>
           <span value>${item.value}</span>
         `, '')}
-        </div>
+        </code>
+        ${localModifications.length ? `
+          <h6 local-modifications>Local Modifications / Inline Styles</h6>
+          <code>${localModifications.reduce((items, item) => `
+            ${items}
+            <span prop>${item.prop}:</span>
+            <span value>${item.value}</span>
+          `, '')}
+          </code>
+        ` : ''}
       </figure>
     `
   }

--- a/app/components/metatip/metatip.element.js
+++ b/app/components/metatip/metatip.element.js
@@ -1,5 +1,6 @@
 import $ from 'blingblingjs'
 import { createClassname } from '../../utilities/'
+import { draggable } from '../../features/'
 import { MetatipStyles } from '../styles.store'
 
 export class Metatip extends HTMLElement {
@@ -31,6 +32,12 @@ export class Metatip extends HTMLElement {
   observe() {
     $('h5 > a', this.$shadow).on('click mouseenter', this.dispatchQuery.bind(this))
     $('h5 > a', this.$shadow).on('mouseleave', this.dispatchUnQuery.bind(this))
+
+    draggable({
+      el: this,
+      surface: this.$shadow.querySelector('header'),
+      cursor: 'grab',
+    })
   }
 
   unobserve() {
@@ -43,6 +50,7 @@ export class Metatip extends HTMLElement {
       bubbles: true
     }))
     this.unobserve()
+    this.teardown()
   }
 
   set meta(data) {

--- a/app/components/selection/distance.element.css
+++ b/app/components/selection/distance.element.css
@@ -35,8 +35,8 @@
   align-items: center;
   justify-content: center;
   color: white;
-  text-shadow: 0 0.5px 0 hsla(0, 0%, 0%, 0.4);
-  box-shadow: 0 0.5px 0 hsla(0, 0%, 0%, 0.4);
+  text-shadow: var(--text-shadow);
+  box-shadow: var(--text-shadow);
   background: hsl(var(--line-color) / 75%);
   border: 1px solid hsl(var(--line-color));
   border-radius: 1em;

--- a/app/components/selection/grip.element.js
+++ b/app/components/selection/grip.element.js
@@ -1,5 +1,6 @@
 import { Handles } from './handles.element'
 import { HandleStyles, GripStyles } from '../styles.store'
+import { isFixed } from '../../utilities/';
 
 export class Grip extends Handles {
 
@@ -15,6 +16,7 @@ export class Grip extends Handles {
   }
 
   render({ width, height, top, left }) {
+    this.style.setProperty('--position', isFixed(this.$shadow.host) ? 'fixed' : 'absolute')
     this.style.setProperty('--top', `${top + window.scrollY}px`)
     this.style.setProperty('--left', `${left}px`)
 

--- a/app/components/selection/label.element.css
+++ b/app/components/selection/label.element.css
@@ -17,7 +17,7 @@
   transform: translateY(-100%);
   background: var(--label-bg, hotpink);
   border-radius: 0.2em 0.2em 0 0;
-  text-shadow: 0 0.5px 0 hsla(0, 0%, 0%, 0.4);
+  text-shadow: var(--text-shadow);
   color: white;
   display: inline-flex;
   justify-content: center;

--- a/app/components/vis-bug/model.js
+++ b/app/components/vis-bug/model.js
@@ -32,6 +32,10 @@ export const VisBugModel = {
                       <b>Pin it:</b>
                       <span>click</span>
                     </div>
+                    <div>
+                      <b>Position it:</b>
+                      <span>click & drag by the header area</span>
+                    </div>
                   </div>`,
   },
   x: {

--- a/app/components/vis-bug/vis-bug.element.css
+++ b/app/components/vis-bug/vis-bug.element.css
@@ -31,10 +31,12 @@
   list-style-type: none;
   border-radius: 2em;
   backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
 
   &:first-of-type {
     box-shadow: 0 0.25em 0.5em hsla(0,0%,0%,10%);
     backdrop-filter: blur(5px);
+    -webkit-backdrop-filter: blur(5px);
     background-color: var(--theme-bd-2);
 
     &:active {

--- a/app/components/vis-bug/vis-bug.element.css
+++ b/app/components/vis-bug/vis-bug.element.css
@@ -30,7 +30,7 @@
   padding: 0;
   list-style-type: none;
   border-radius: 2em;
-  backdrop-filter: blur(0);
+  backdrop-filter: blur(5px);
 
   &:first-of-type {
     box-shadow: 0 0.25em 0.5em hsla(0,0%,0%,10%);

--- a/app/features/metatip.js
+++ b/app/features/metatip.js
@@ -4,7 +4,7 @@ import { TinyColor } from '@ctrl/tinycolor'
 import { queryPage } from './search'
 import { getStyles, camelToDash, isOffBounds,
          deepElementFromPoint, getShadowValues,
-         getTextShadowValues
+         getTextShadowValues, firstUsableFontFromFamily
 } from '../utilities/'
 
 const state = {
@@ -162,8 +162,8 @@ const render = (el, tip = document.createElement('visbug-metatip')) => {
         style.value = `${new TinyColor(color)[colormode]()} ${x} ${y} ${blur}`
       }
 
-      if (style.prop.includes('font-family') && style.value.length > 25)
-        style.value = `<span style="max-width: 25ch">${style.value}</span>`
+      if (style.prop.includes('font-family'))
+        style.value = `<span string value>${firstUsableFontFromFamily(style.value)}</span>`
 
       if (style.prop.includes('grid-template-areas'))
         style.value = style.value.replace(/" "/g, '"<br>"')

--- a/app/utilities/styles.js
+++ b/app/utilities/styles.js
@@ -116,3 +116,34 @@ export const getShadowValues = shadow =>
 // returns [full, color, x, y, blur]
 export const getTextShadowValues = shadow =>
   /([^\)]+\)) ([^\s]+) ([^\s]+) ([^\s]+)/.exec(shadow)
+
+const fontCacheMap = new Map()
+export const firstUsableFontFromFamily = family => {
+  if (fontCacheMap.has(family))
+    return fontCacheMap.get(family)
+
+  // todo: check cache for family string and return already computed value
+  const fonts = family.split(',')
+  const canvas = window.document.createElement('canvas')
+  const context = canvas.getContext('2d')
+
+  const match = fonts
+    .map(font => font.trim())
+    .map(name => {
+      const matches = String(name).match(/^["']?(.+?)["']?$/i);
+      return Array.isArray(matches) ? matches[1] : '';
+    })
+    .map(fontName => {
+      const baselineSize = context.measureText(12).width
+
+      context.font = `12px ${fontName}, sans-serif`
+
+      return baselineSize !== context.measureText('font-test').width 
+        ? fontName 
+        : false
+  }).filter(value => value !== false)[0]
+
+  fontCacheMap.set(family, match)
+
+  return match
+}


### PR DESCRIPTION
- metatip legibility, softness and grouping update
- easily position a metatip after sticking it #489 
- restores grip elements to moving ux
- reports active computed font, not just the family list
- small borders around color swatches so a color isnt lost on the background
- minor dark theme enhancements

![image](https://user-images.githubusercontent.com/1134620/103322811-a12f1f80-49f4-11eb-95dc-7ff7da116b1f.png)

