### PR TITLE
ensure the `<a node></a>` is rendered in HTML format

### DIFF
--- a/app/components/selection/label.element.js
+++ b/app/components/selection/label.element.js
@@ -49,7 +49,7 @@ export class Label extends HTMLElement {
 
   set text(content) {
     this.$shadow.childElementCount
-      ? this.$shadow.firstElementChild.textContent = content
+      ? this.$shadow.firstElementChild.innerHTML = content
       : this._text = content
   }
 

--- a/app/features/selectable.test.js
+++ b/app/features/selectable.test.js
@@ -1,6 +1,6 @@
 import test from 'ava'
 
-import { setupPptrTab, teardownPptrTab, changeMode, getActiveTool, dragAndDropElement }
+import { setupPptrTab, teardownPptrTab, changeMode }
 from '../../tests/helpers'
 
 const test_selector   = '[intro] b'

--- a/app/features/selectable.test.js
+++ b/app/features/selectable.test.js
@@ -1,0 +1,64 @@
+import test from 'ava'
+
+import { setupPptrTab, teardownPptrTab, changeMode, getActiveTool, dragAndDropElement }
+from '../../tests/helpers'
+
+const test_selector   = '[intro] b'
+
+test.beforeEach(setupPptrTab)
+
+test('Can show 1 label on click', async t => {
+  await changeMode({tool: 'font', page: t.context.page})
+  const { page } = t.context
+
+  await page.click(test_selector)
+
+  const label_element = await page.evaluate(`document.querySelectorAll('visbug-label').length`)
+
+  t.is(label_element, 1)
+  t.pass()
+})
+
+test('Can show tag name label on click', async t => {
+  await changeMode({tool: 'font', page: t.context.page})
+  const { page } = t.context
+
+  await page.click(test_selector)
+
+  const label_element = await page.evaluate(
+    `document.querySelector('visbug-label').$shadow.querySelector('span a').textContent`
+  );
+
+  t.is(label_element, 'b');
+  t.pass()
+})
+
+test('Can show layout property label on click', async t => {
+  await changeMode({tool: 'align', page: t.context.page})
+  const { page } = t.context
+
+  await page.click(test_selector)
+
+  const label_element = await page.evaluate(
+    `document.querySelector('visbug-label').$shadow.querySelector('span').textContent`
+  );
+
+  t.is(label_element, 'inline');
+  t.pass()
+})
+
+test('Can show proper tag name label after position tool clicked', async t => {
+  await changeMode({tool: 'position', page: t.context.page})
+  const { page } = t.context
+
+  await page.click(test_selector)
+
+  const label_element = await page.evaluate(
+    `document.querySelector('visbug-label').$shadow.querySelector('span a').textContent`
+  );
+
+  t.is(label_element, "b");
+  t.pass();
+})
+
+test.afterEach(teardownPptrTab)


### PR DESCRIPTION
Steps to reproduce: activate the position tool first, and then try to click an element on the page. The label changed from `<tagName>` to `<a node>tagName</a> <a></a>`.

This PR replaced `textContent` to ensure we are setting the `<a node></a>` in HTML format, also added more test cases for these issues.

