### PR TITLE
toolbar drag #541

### DIFF
--- a/app/components/vis-bug/vis-bug.element.js
+++ b/app/components/vis-bug/vis-bug.element.js
@@ -87,9 +87,20 @@ export default class VisBug extends HTMLElement {
     $('li[data-tool]', this.$shadow).on('click', e =>
       this.toolSelected(e.currentTarget) && e.stopPropagation())
 
+    const main_ol = this.$shadow.querySelector('ol:not([colors])')
+
+    Array.from(main_ol.querySelectorAll('li[data-tool], svg'))
+    .forEach(toolButton => {
+      draggable({
+        el:this,
+        surface: toolButton,
+        cursor: 'grab',
+      })
+    })
+
     draggable({
       el:this,
-      surface: this.$shadow.querySelector('ol:not([colors])'),
+      surface: main_ol,
       cursor: 'grab',
     })
 

--- a/app/components/vis-bug/vis-bug.element.js
+++ b/app/components/vis-bug/vis-bug.element.js
@@ -84,17 +84,22 @@ export default class VisBug extends HTMLElement {
       ? this.getAttribute('color-scheme')
       : this.setAttribute('color-scheme', 'auto')
 
-    $('li[data-tool]', this.$shadow).on('click', e =>
-      this.toolSelected(e.currentTarget) && e.stopPropagation())
-
     const main_ol = this.$shadow.querySelector('ol:not([colors])')
+    const toolButtons = $('li[data-tool], svg', main_ol)
 
-    Array.from(main_ol.querySelectorAll('li[data-tool], svg'))
+    const clickEvent = (e) => {
+      const target = e.currentTarget || e.target
+      const tool = target?.parentNode || target
+      this.toolSelected(tool) && e.stopPropagation();
+    }
+
+    Array.from(toolButtons)
     .forEach(toolButton => {
       draggable({
         el:this,
         surface: toolButton,
-        cursor: 'grab',
+        cursor: 'pointer',
+        clickEvent: clickEvent
       })
     })
 

--- a/app/components/vis-bug/vis-bug.element.js
+++ b/app/components/vis-bug/vis-bug.element.js
@@ -85,15 +85,15 @@ export default class VisBug extends HTMLElement {
       : this.setAttribute('color-scheme', 'auto')
 
     const main_ol = this.$shadow.querySelector('ol:not([colors])')
-    const toolButtons = $('li[data-tool], svg', main_ol)
+    const buttonPieces = $('li[data-tool], li[data-tool] *', main_ol)
 
     const clickEvent = (e) => {
       const target = e.currentTarget || e.target
-      const tool = target?.parentNode || target
-      this.toolSelected(tool) && e.stopPropagation();
+      const toolButton = target.closest('[data-tool]')
+      if (toolButton) this.toolSelected(toolButton) && e.stopPropagation();
     }
 
-    Array.from(toolButtons)
+    Array.from(buttonPieces)
     .forEach(toolButton => {
       draggable({
         el:this,

--- a/app/features/font.test.js
+++ b/app/features/font.test.js
@@ -30,7 +30,7 @@ test('Can Be Deactivated', async t => {
   const { page } = t.context
 
   t.is(await getActiveTool(page), tool)
-  await page.evaluate(`document.querySelector('vis-bug').$shadow.querySelector('li[data-tool="padding"]').click()`)
+  await changeMode({ tool: 'padding', page })
   t.is(await getActiveTool(page), 'padding')
 
   t.pass()

--- a/app/features/margin.test.js
+++ b/app/features/margin.test.js
@@ -29,7 +29,7 @@ test('Can Be Deactivated', async t => {
   const { page } = t.context
 
   t.is(await getActiveTool(page), tool)
-  await page.evaluate(`document.querySelector('vis-bug').$shadow.querySelector('li[data-tool="padding"]').click()`)
+  await changeMode({ tool: 'padding', page })
   t.is(await getActiveTool(page), 'padding')
 
   t.pass()

--- a/app/features/metatip.test.js
+++ b/app/features/metatip.test.js
@@ -25,7 +25,7 @@ test('Can Be Deactivated', async t => {
   const { page } = t.context
 
   t.is(await getActiveTool(page), tool)
-  await page.evaluate(`document.querySelector('vis-bug').$shadow.querySelector('li[data-tool="padding"]').click()`)
+  await changeMode({ tool: 'padding', page })
   t.is(await getActiveTool(page), 'padding')
 
   t.pass()

--- a/app/features/move.test.js
+++ b/app/features/move.test.js
@@ -29,7 +29,7 @@ test('Can Be Deactivated', async t => {
   const { page } = t.context
 
   t.is(await getActiveTool(page), tool)
-  await page.evaluate(`document.querySelector('vis-bug').$shadow.querySelector('li[data-tool="padding"]').click()`)
+  await changeMode({ tool: 'padding', page })
   t.is(await getActiveTool(page), 'padding')
 
   t.pass()

--- a/app/features/padding.test.js
+++ b/app/features/padding.test.js
@@ -29,7 +29,7 @@ test('Can Be Deactivated', async t => {
   const { page } = t.context
 
   t.is(await getActiveTool(page), tool)
-  await page.evaluate(`document.querySelector('vis-bug').$shadow.querySelector('li[data-tool="margin"]').click()`)
+  await changeMode({ tool: 'margin', page })
   t.is(await getActiveTool(page), 'margin')
 
   t.pass()

--- a/app/features/position.js
+++ b/app/features/position.js
@@ -131,7 +131,7 @@ export function draggable({el, surface = el, cursor = 'move', clickEvent}) {
     }
 
     const treatAsClick = !state.travelDistance || state.travelDistance < 5
-    if (treatAsClick) clickEvent?.(e);
+    if (clickEvent && treatAsClick) clickEvent(e);
     state.travelDistance = 0 // reset after
   }
 

--- a/app/features/position.js
+++ b/app/features/position.js
@@ -43,7 +43,7 @@ export function Position() {
   }
 }
 
-export function draggable({el, surface = el, cursor = 'move'}) {
+export function draggable({el, surface = el, cursor = 'move', clickEvent}) {
    const state = {
     target: el,
     surface,
@@ -55,7 +55,8 @@ export function draggable({el, surface = el, cursor = 'move'}) {
     element: {
       x: 0,
       y: 0,
-    }
+    },
+    travelDistance: 0
   }
 
   const setup = () => {
@@ -99,9 +100,10 @@ export function draggable({el, surface = el, cursor = 'move'}) {
       state.element.y  = parseInt(getStyle(el, 'top'))
     }
 
-    state.mouse.x      = e.clientX
-    state.mouse.y      = e.clientY
-    state.mouse.down   = true
+    state.mouse.x        = e.clientX
+    state.mouse.y        = e.clientY
+    state.mouse.down     = true
+    state.travelDistance = 0
   }
 
   const onMouseUp = e => {
@@ -127,6 +129,10 @@ export function draggable({el, surface = el, cursor = 'move'}) {
       state.element.x    = parseInt(el.style.left) || 0
       state.element.y    = parseInt(el.style.top) || 0
     }
+
+    const treatAsClick = !state.travelDistance || state.travelDistance < 5
+    if (treatAsClick) clickEvent?.(e);
+    state.travelDistance = 0 // reset after
   }
 
   const onMouseMove = e => {
@@ -146,6 +152,8 @@ export function draggable({el, surface = el, cursor = 'move'}) {
       el.style.left = state.element.x + e.clientX - state.mouse.x + 'px'
       el.style.top  = state.element.y + e.clientY - state.mouse.y + 'px'
     }
+
+    state.travelDistance += 1
   }
 
   setup()

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -13,7 +13,11 @@ export const teardownPptrTab = async ({context:{ page, browser }}) => {
 }
 
 export const changeMode = async ({page, tool}) =>
-  await page.evaluateHandle(`document.querySelector('vis-bug').$shadow.querySelector('li[data-tool=${tool}]').click()`)
+  await page.evaluateHandle(`
+    var mouseUpEvent = document.createEvent("MouseEvents");
+    mouseUpEvent.initEvent("mouseup", true, true);
+    document.querySelector('vis-bug').$shadow.querySelector('li[data-tool=${tool}]').dispatchEvent(mouseUpEvent);
+  `)
 
 export const getActiveTool = async page =>
   await page.$eval('vis-bug', el =>


### PR DESCRIPTION
fix for part of #541:
- enable dragging `<li data-tool>`'s within the toolbar too, as well as children of those `<li data-tool>`'s
- prevent tool change after drag - the tool changes when you click, not when you drag
- made sure reliable response to clicks and dragging by checking all children of the `<li data-tool>`

<img src="https://user-images.githubusercontent.com/18131787/147015826-51405af5-7c8c-4340-b594-b54cfca6c2a2.gif" height="340" alt="animation of clicking and dragging the svg or path or li part of a button, all working">
