### PR TITLE
add support for resizing elements

### DIFF
--- a/app/components/index.js
+++ b/app/components/index.js
@@ -1,4 +1,5 @@
 export { Handles }    from './selection/handles.element'
+export { Handle }    from './selection/handle.element'
 export { Hover }      from './selection/hover.element'
 export { Label }      from './selection/label.element'
 export { Gridlines }  from './selection/gridlines.element'

--- a/app/components/selection/corners.element.js
+++ b/app/components/selection/corners.element.js
@@ -1,11 +1,11 @@
 import { Handles } from './handles.element'
-import { HandleStyles, CornerStyles } from '../styles.store'
+import { HandlesStyles, CornerStyles } from '../styles.store'
 
 export class Corners extends Handles {
 
   constructor() {
     super()
-    this.styles = [HandleStyles, CornerStyles]
+    this.styles = [HandlesStyles, CornerStyles]
   }
 
   render({ width, height, top, left }) {

--- a/app/components/selection/grip.element.js
+++ b/app/components/selection/grip.element.js
@@ -1,12 +1,12 @@
 import { Handles } from './handles.element'
-import { HandleStyles, GripStyles } from '../styles.store'
+import { HandlesStyles, GripStyles } from '../styles.store'
 import { isFixed } from '../../utilities/';
 
 export class Grip extends Handles {
 
   constructor() {
     super()
-    this.styles = [HandleStyles, GripStyles]
+    this.styles = [HandlesStyles, GripStyles]
   }
 
   toggleHovering({hovering}) {

--- a/app/components/selection/handle.element.css
+++ b/app/components/selection/handle.element.css
@@ -1,0 +1,77 @@
+@import "../_variables.css";
+
+:host {
+	display: grid;
+	grid-area: 1 / -1;
+	place-self: var(--align-self, center) var(--justify-self, center);
+	transform: translate(var(--translate-x, 0), var(--translate-y, 0));
+}
+
+:host([hidden]) {
+	display: none;
+}
+
+:host > button {
+	pointer-events: auto;
+	background-color: white;
+	border: 1px solid hotpink;
+	padding: 0;
+	width: 0.5rem;
+	height: 0.5rem;
+	border-radius: 50%;
+	position: relative;
+	cursor: var(--cursor);
+
+	/* increase tap target size */
+	&::before {
+		content: '';
+		position: absolute;
+		inset: -0.5rem;
+	}
+}
+
+:host([placement^="top"]) {
+	--align-self: start;
+	--translate-y: -50%;
+}
+
+:host([placement^="bottom"]) {
+	--align-self: end;
+	--translate-y: 50%;
+}
+
+:host([placement$="start"]) {
+	--justify-self: start;
+	--translate-x: -50%;
+}
+
+:host([placement$="end"]) {
+	--justify-self: end;
+	--translate-x: 50%;
+}
+
+:host([placement^="top"]),
+:host([placement^="bottom"]) {
+	--cursor: ns-resize;
+}
+
+:host([placement$="start"]),
+:host([placement$="end"]) {
+	--cursor: ew-resize;
+}
+
+:host([placement="top-start"]) {
+	--cursor: nw-resize;
+}
+
+:host([placement="top-end"]) {
+	--cursor: ne-resize;
+}
+
+:host([placement="bottom-start"]) {
+	--cursor: sw-resize;
+}
+
+:host([placement="bottom-end"]) {
+	--cursor: se-resize;
+}

--- a/app/components/selection/handle.element.js
+++ b/app/components/selection/handle.element.js
@@ -1,0 +1,37 @@
+import $ from 'blingblingjs'
+import { HandleStyles } from '../styles.store'
+
+export class Handle extends HTMLElement {
+
+	constructor() {
+		super()
+    this.$shadow = this.attachShadow({mode: 'closed'})
+    this.styles = [HandleStyles]
+	}
+	
+  connectedCallback() {
+    this.$shadow.adoptedStyleSheets = this.styles
+		this.$shadow.innerHTML = this.render();
+		
+		this.button = this.$shadow.querySelector('button')
+		this.placement = this.getAttribute('placement')
+	}
+
+	static get observedAttributes() {
+    return ['placement']
+  }
+
+	attributeChangedCallback(name, oldValue, newValue) {
+    if (name === 'placement') {
+			this.placement = newValue
+		}
+  }
+
+	render() {
+		return `
+			<button type="button" aria-label="Resize"></button>
+		`
+	}
+}
+
+customElements.define('visbug-handle', Handle)

--- a/app/components/selection/handles.element.css
+++ b/app/components/selection/handles.element.css
@@ -1,10 +1,18 @@
 @import "../_variables.css";
 
-:host > svg {
+:host {
   position: var(--position, 'absolute');
   top: var(--top);
   left: var(--left);
   overflow: visible;
   pointer-events: none;
   z-index: var(--layer-3);
+  width: var(--width);
+  height: var(--height);
+  display: grid;
+  isolation: isolate;
+}
+
+:host > svg {
+  position: absolute;
 }

--- a/app/components/selection/handles.element.js
+++ b/app/components/selection/handles.element.js
@@ -1,5 +1,5 @@
 import $ from 'blingblingjs'
-import { HandleStyles } from '../styles.store'
+import { HandlesStyles } from '../styles.store'
 import { isFixed } from '../../utilities/';
 
 export class Handles extends HTMLElement {
@@ -7,20 +7,20 @@ export class Handles extends HTMLElement {
   constructor() {
     super()
     this.$shadow = this.attachShadow({mode: 'closed'})
-    this.styles = [HandleStyles]
-    this.on_resize = this.on_resize.bind(this)
+    this.styles = [HandlesStyles]
+    this.on_resize = this.on_window_resize.bind(this)
   }
 
   connectedCallback() {
     this.$shadow.adoptedStyleSheets = this.styles
-    window.addEventListener('resize', this.on_resize)
+    window.addEventListener('resize', this.on_window_resize)
   }
 
   disconnectedCallback() {
-    window.removeEventListener('resize', this.on_resize)
+    window.removeEventListener('resize', this.on_window_resize)
   }
 
-  on_resize() {
+  on_window_resize() {
     window.requestAnimationFrame(() => {
       const node_label_id = this.$shadow.host.getAttribute('data-label-id')
       const [source_el] = $(`[data-label-id="${node_label_id}"]`)
@@ -62,6 +62,8 @@ export class Handles extends HTMLElement {
     this.style.setProperty('--top', `${top + (isFixed ? 0 : window.scrollY)}px`)
     this.style.setProperty('--left', `${left}px`)
     this.style.setProperty('--position', isFixed ? 'fixed' : 'absolute')
+    this.style.setProperty('--width', `${width}px`)
+    this.style.setProperty('--height', `${height}px`)
 
     return `
       <svg
@@ -71,15 +73,15 @@ export class Handles extends HTMLElement {
         version="1.1" xmlns="http://www.w3.org/2000/svg"
       >
         <rect stroke="hotpink" fill="none" width="100%" height="100%"></rect>
-        <circle stroke="hotpink" fill="white" cx="0" cy="0" r="2"></circle>
-        <circle stroke="hotpink" fill="white" cx="100%" cy="0" r="2"></circle>
-        <circle stroke="hotpink" fill="white" cx="100%" cy="100%" r="2"></circle>
-        <circle stroke="hotpink" fill="white" cx="0" cy="100%" r="2"></circle>
-        <circle fill="hotpink" cx="${width/2}" cy="0" r="2"></circle>
-        <circle fill="hotpink" cx="0" cy="${height/2}" r="2"></circle>
-        <circle fill="hotpink" cx="${width/2}" cy="${height}" r="2"></circle>
-        <circle fill="hotpink" cx="${width}" cy="${height/2}" r="2"></circle>
       </svg>
+      <visbug-handle placement="top-start"></visbug-handle>
+      <visbug-handle placement="top-center"></visbug-handle>
+      <visbug-handle placement="top-end"></visbug-handle>
+      <visbug-handle placement="middle-start"></visbug-handle>
+      <visbug-handle placement="middle-end"></visbug-handle>
+      <visbug-handle placement="bottom-start"></visbug-handle>
+      <visbug-handle placement="bottom-center"></visbug-handle>
+      <visbug-handle placement="bottom-end"></visbug-handle>
     `
   }
 }

--- a/app/components/selection/hover.element.js
+++ b/app/components/selection/hover.element.js
@@ -1,11 +1,11 @@
 import { Handles } from './handles.element'
-import { HandleStyles, HoverStyles } from '../styles.store'
+import { HandlesStyles, HoverStyles } from '../styles.store'
 
 export class Hover extends Handles {
 
   constructor() {
     super()
-    this.styles = [HandleStyles, HoverStyles]
+    this.styles = [HandlesStyles, HoverStyles]
   }
 
   render({ width, height, top, left }, node_label_id, isFixed) {

--- a/app/components/styles.store.js
+++ b/app/components/styles.store.js
@@ -1,7 +1,8 @@
 import 'construct-style-sheets-polyfill'
 
 import { default as visbug_css }     from './vis-bug/vis-bug.element.css'
-import { default as handle_css }     from './selection/handles.element.css'
+import { default as handles_css }     from './selection/handles.element.css'
+import { default as handle_css }     from './selection/handle.element.css'
 import { default as hover_css }      from './selection/hover.element.css'
 import { default as corners_css }    from './selection/corners.element.css'
 import { default as distance_css }   from './selection/distance.element.css'
@@ -30,6 +31,7 @@ const constructStylesheet = (styles, stylesheet = new CSSStyleSheet()) => {
 }
 
 export const VisBugStyles         = constructStylesheet(visbug_css)
+export const HandlesStyles        = constructStylesheet(handles_css)
 export const HandleStyles         = constructStylesheet(handle_css)
 export const HoverStyles          = constructStylesheet(hover_css)
 export const CornerStyles         = constructStylesheet(corners_css)

--- a/app/components/vis-bug/vis-bug.element.js
+++ b/app/components/vis-bug/vis-bug.element.js
@@ -2,7 +2,7 @@ import $          from 'blingblingjs'
 import hotkeys    from 'hotkeys-js'
 
 import {
-  Handles, Label, Overlay, Gridlines, Corners,
+  Handles, Handle, Label, Overlay, Gridlines, Corners,
   Hotkeys, Metatip, Ally, Distance, BoxModel, Grip
 } from '../'
 


### PR DESCRIPTION
Closes #17 

- Changed the svg circles in `visbug-handles` to the new `visbug-handle` element.
- Pluralized existing variables for `handle-css` and `HandleStyles` and added new singular ones for the element
- The new element takes an attribute called `placement`. e.g. `<visbug-handle placement="top-end">`.
- This attribute handles both the conditional styling as well as the conditional logic for resizing.

Order of events is as follows:
1. pointerdown on visbug-handle triggers `on_element_resize_start`
   - this saves the initial state of the resizing
   - adds listeners for pointermove and pointerup on document
2. pointermove on document triggers `on_element_resize_move`
   - this is where the resizing is calculated and triggered via requestAnimationFrame
3. pointerup on document triggers `on_element_resize_end`
   - this is where we detach the pointermove listener
   - also restore any original styles that we modified for the resize (e.g. cursor and transition)

![Screen recording showing a demo of resizing various elements](https://user-images.githubusercontent.com/9084735/193481598-a9486d43-49a5-402a-8233-70c24d24095e.gif)
