### PR TITLE
Add new plugin 'placeholdifier'

### DIFF
--- a/app/plugins/placeholdifier.js
+++ b/app/plugins/placeholdifier.js
@@ -1,0 +1,21 @@
+import { loadStyles } from '../utilities/styles.js'
+
+export const commands = [
+    'placeholdifier',
+]
+
+export const description = 'turn the page into a live wireframe'
+
+export default async function() {
+    await loadStyles(['https://unpkg.com/placeholdifier/placeholdifier.css'])
+
+    const ignored = ['script', 'link']
+    const body = document.querySelector('body')
+    const elements = Array.from(body.querySelectorAll('*'))
+        .filter(el => !ignored.includes(el.tagName?.toLowerCase()))
+    
+    elements.forEach(el => {
+        if (Array.from(el.classList).includes("placeholdify")) return;
+        el.classList.add('placeholdify');
+    })
+}

--- a/app/plugins/placeholdifier.js
+++ b/app/plugins/placeholdifier.js
@@ -15,7 +15,7 @@ export default async function() {
         .filter(el => !ignored.includes(el.tagName?.toLowerCase()))
     
     elements.forEach(el => {
-        if (Array.from(el.classList).includes("placeholdify")) return;
+        if (Array.from(el.classList).includes('placeholdify')) return;
         el.classList.add('placeholdify');
     })
 }


### PR DESCRIPTION
Fixes #462

Adds [placeholdifier](https://github.com/pomber/placeholdifier) as a new plugin. All thats going on here is we iterate through all the elements that are children of the `<body>` and then add the class 'placeholdify' to each element. The command 'placeholdifier' would select all the elements inside the body and add 'placeholdify' creating the live wireframe effect.

TODO:
- there needs to be a way to remove the 'placeholdify' class when users are done using the plugin, in the CodePen demo I just added a reset button to remove the class and revert from the live wireframe view
- tests :)

#### Recording
https://user-images.githubusercontent.com/48612525/195524427-e634b02b-9187-4bc3-95ea-390b0155fee8.mov


#### Resources
- https://github.com/pomber/placeholdifier
- https://codepen.io/tannerdolby/pen/YzLBqyX