### PR TITLE
simulate translated text size expansion

### DIFF
--- a/app/plugins/_registry.js
+++ b/app/plugins/_registry.js
@@ -17,6 +17,7 @@ import { commands as remove_css_commands, description as remove_css_description,
 import { commands as detect_overflows_commands, description as detect_overflows_description, default as DetectOverflows } from './detect-overflows'
 import { commands as loop_thru_widths_commands, description as loop_thru_widths_description, default as LoopThruWidths } from './loop-through-widths'
 import { commands as placeholdifier_commands, description as placeholdifier_description, default as PlaceholdifierPlugin } from './placeholdifier'
+import { commands as expand_text_commands, description as expand_text_description, default as ExpandTextPlugin } from './expand-text'
 
 const commandsToHash = (plugin_commands, plugin_fn) =>
   plugin_commands.reduce((commands, command) =>
@@ -43,6 +44,7 @@ export const PluginRegistry = new Map(Object.entries({
   ...commandsToHash(detect_overflows_commands, DetectOverflows),
   ...commandsToHash(loop_thru_widths_commands, LoopThruWidths),
   ...commandsToHash(placeholdifier_commands, PlaceholdifierPlugin),
+  ...commandsToHash(expand_text_commands, ExpandTextPlugin),
 }))
 
 export const PluginHints = [
@@ -64,6 +66,7 @@ export const PluginHints = [
   {command: detect_overflows_commands[0], description: detect_overflows_description},
   {command: loop_thru_widths_commands[0], description: loop_thru_widths_description},
   {command: placeholdifier_commands[0], description: placeholdifier_description},
+  {command: expand_text_commands[0], description: expand_text_description},
   ...colorblind_commands.map(cbc => {
     return {
       command: cbc, description: `simulate ${cbc}`

--- a/app/plugins/_registry.js
+++ b/app/plugins/_registry.js
@@ -3,6 +3,7 @@ import { commands as barrel_roll_commands, description as barrel_roll_descriptio
 import { commands as pesticide_commands, description as pesticide_description, default as PesticidePlugin } from './pesticide'
 import { commands as construct_commands, description as construct_description, default as ConstructPlugin } from './construct'
 import { commands as construct_debug_commands, description as construct_debug_description, default as ConstructDebugPlugin } from './construct.debug'
+import { commands as ct_head_scan_commands, description as ct_head_scan_description, default as CtHeadScanPlugin } from './ct-head-scan'
 import { commands as wireframe_commands, description as wireframe_description, default as WireframePlugin } from './wireframe'
 import { commands as skeleton_commands, description as skeleton_description, default as SkeletonPlugin } from './skeleton'
 import { commands as tag_debugger_commands, description as tag_debugger_description, default as TagDebuggerPlugin } from './tag-debugger'
@@ -27,6 +28,7 @@ export const PluginRegistry = new Map(Object.entries({
   ...commandsToHash(pesticide_commands, PesticidePlugin),
   ...commandsToHash(construct_commands, ConstructPlugin),
   ...commandsToHash(construct_debug_commands, ConstructDebugPlugin),
+  ...commandsToHash(ct_head_scan_commands, CtHeadScanPlugin),
   ...commandsToHash(wireframe_commands, WireframePlugin),
   ...commandsToHash(skeleton_commands, SkeletonPlugin),
   ...commandsToHash(tag_debugger_commands, TagDebuggerPlugin),
@@ -47,6 +49,7 @@ export const PluginHints = [
   {command: pesticide_commands[0], description: pesticide_description},
   {command: construct_commands[0], description: construct_description},
   {command: construct_debug_commands[0], description: construct_debug_description},
+  {command: ct_head_scan_commands[0], description: ct_head_scan_description},
   {command: wireframe_commands[0], description: wireframe_description},
   {command: skeleton_commands[0], description: skeleton_description},
   {command: tag_debugger_commands[0], description: tag_debugger_description},

--- a/app/plugins/ct-head-scan.js
+++ b/app/plugins/ct-head-scan.js
@@ -1,0 +1,13 @@
+export const commands = [
+  'head scan',
+]
+
+export const description = `diagnose potential performance issues in your page's tags`
+
+export default function () {
+  const ct = document.createElement("link");
+  ct.rel = "stylesheet";
+  ct.href = "https://csswizardry.com/ct/ct.css";
+  ct.classList.add("ct");
+  document.head.appendChild(ct);
+}

--- a/app/plugins/expand-text.js
+++ b/app/plugins/expand-text.js
@@ -1,0 +1,156 @@
+export const commands = [
+  'expand-text',
+]
+
+export const description = 'simulate translated text expansion based on a w3.org table'
+
+export default async function() {
+  const settings = {
+    expanded: true,
+    predictableMode: false,
+  };
+  
+  const accents = "̟́";
+  
+  console.log(
+    "Reference expansion table: https://www.w3.org/International/articles/article-text-size"
+  );
+  
+  alert(
+    'Click on the page, then: \n\nhit the Ctrl key to toggle translation size expansion, or \n\nhit the Shift key to toggle random insertion of spaces.'
+  );
+  
+  englishToExpectedEuropeanLanguageExpansionSize();
+  
+  document.body.addEventListener("keydown", function (event) {
+    if (event.ctrlKey) {
+      settings.expanded = !settings.expanded;
+      if (settings.expanded) {
+        englishToExpectedEuropeanLanguageExpansionSize();
+      } else {
+        backToEnglishSize();
+      }
+    } else if (event.shiftKey) {
+      settings.predictableMode = !settings.predictableMode;
+      if (settings.predictableMode) {
+        alert("Spaces will NOT be randomly included.");
+      } else {
+        alert("Spaces WILL be randomly included.");
+      }
+    }
+  });
+  
+  function englishToExpectedEuropeanLanguageExpansionSize() {
+    const elementsWithText = [...document.querySelectorAll("body *")]
+      .filter((el) => hasText(el))
+      .reverse();
+    elementsWithText.forEach((el) => setExpandedSizeText(el));
+  }
+  
+  function backToEnglishSize() {
+    const elementsWithText = [...document.querySelectorAll("body *")]
+      .filter((el) => hasText(el))
+      .reverse();
+    elementsWithText.forEach((el) => setEnglishSizeText(el));
+  }
+  
+  function hasText(element) {
+    return (
+      element.innerText && element.innerText.trim() && hasChildTextNode(element)
+    );
+  }
+  
+  function hasChildTextNode(element) {
+    return [...element.childNodes].some((n) => n.nodeType === Node.TEXT_NODE);
+  }
+  
+  function setEnglishSizeText(element) {
+    const elementData = element.getAttribute(
+      "data-englishToExpectedEuropeanLanguageExpansionSize"
+    );
+    if (elementData) {
+      const originalLength = JSON.parse(elementData).originalLength;
+      const expandedLength = JSON.parse(elementData).expandedLength;
+      const difference = expandedLength - originalLength;
+      const multiplier = 1 + accents.length;
+      element.innerHTML = element.innerHTML.slice(0, -difference * multiplier);
+    }
+  }
+  
+  function setExpandedSizeText(element) {
+    const elementData = element.getAttribute(
+      "data-englishToExpectedEuropeanLanguageExpansionSize"
+    );
+    const alreadyExpanded =
+      elementData ||
+      element.querySelectorAll(
+        "[data-englishToExpectedEuropeanLanguageExpansionSize]"
+      ).length;
+    if (alreadyExpanded) {
+      if (
+        element.hasAttribute(
+          "data-englishToExpectedEuropeanLanguageExpansionSize"
+        )
+      ) {
+        const originalLength = JSON.parse(elementData).originalLength;
+        const expandedLength = JSON.parse(elementData).expandedLength;
+        element.innerHTML = element.innerHTML.slice(0, originalLength);
+        element.innerHTML += getExpandedString(expandedLength - originalLength);
+      }
+    } else {
+      const originalHtmlLength = element.innerHTML.length;
+      const originalLength = element.innerText.trim().length;
+      const expandedLength = useExpansionTable(element.innerText.trim());
+      const difference = expandedLength - originalLength;
+      element.innerHTML += getExpandedString(difference);
+      const data = {
+        originalLength: originalHtmlLength,
+        expandedLength: originalHtmlLength + difference,
+      };
+      element.setAttribute(
+        "data-englishToExpectedEuropeanLanguageExpansionSize",
+        JSON.stringify(data)
+      );
+    }
+  }
+  
+  function useExpansionTable(englishText) {
+    let expandedLength = englishText.length;
+    if (englishText.length <= 10) {
+      expandedLength = englishText.length * 3;
+    } else if (englishText.length <= 20) {
+      expandedLength = englishText.length * 2;
+    } else if (englishText.length <= 30) {
+      expandedLength = englishText.length * 1.8;
+    } else if (englishText.length <= 50) {
+      expandedLength = englishText.length * 1.6;
+    } else if (englishText.length <= 70) {
+      expandedLength = englishText.length * 1.7;
+    } else if (englishText.length > 70) {
+      expandedLength = englishText.length * 1.3;
+    }
+    return Math.ceil(expandedLength);
+  }
+  
+  function getExpandedString(length) {
+    let output = "";
+    const abc = "abcdefghijklmnopqrstuvwxyz";
+    const chanceOfSpace = settings.predictableMode ? 0 : 0.1;
+    let i = 0;
+    while (i < length) {
+      const notLastCharacter = i < length - 1;
+      const precededBySpace = i > 0 && output[i - 1] === " ";
+      if (
+        notLastCharacter &&
+        !precededBySpace &&
+        Math.random() >= 1 - chanceOfSpace
+      ) {
+        output += " " + accents;
+      } else {
+        output += abc[i % 26] + accents;
+      }
+      i++;
+    }
+    return output;
+  }
+}


### PR DESCRIPTION
closes #583 

## my test steps:

1. `npm run dev:extension`
2. chrome://extensions/ --> Load unpacked --> choose /extension folder
3. tested on https://en.wiktionary.org/wiki/Wiktionary:Main_Page 

<img width="1273" alt="Screen Shot 2023-01-26 at 8 08 26 PM" src="https://user-images.githubusercontent.com/18131787/215001829-a5d2432c-b90d-41fd-913a-a09c31922753.png">

## considerations:

- i went with `/expand-text`, instead of `/text-expand`, to avoid triggering both `/text` and `/text-expand` as you type.
- the user still has to click on the page for the <kbd>Ctrl</kbd> or <kbd>Shift</kbd> key events to fire, which was an intentional choice. that is, for simple implementation, and since the focus stays in the plugin search box. that said, i'm open to looking into automatically collapsing the search box and setting focus on the `<body>` when `/text-expand` is typed.
