### PR TITLE
fix: uses parseFloat to handle borderWidth between 0 and 1

### DIFF
--- a/app/utilities/styles.js
+++ b/app/utilities/styles.js
@@ -30,7 +30,7 @@ export const getStyles = el => {
 
   const { borderColor, borderWidth, borderStyle } = borders
 
-  if (parseInt(borderWidth) > 0) {
+  if (parseFloat(borderWidth) > 0) {
     vettedStyles.push({
       prop: 'borderColor',
       value: borderColor,


### PR DESCRIPTION
Hello! First PR on VisBug 😄 

Sometimes depending on the browser zoom, the borderWidth can be between 0 and 1. Because of the parseInt, in these cases, the value was hidden, even though it was greater than 0.

Example, with a zoom of 150% and a borderWidth of 1px, the rendered borderWidth is 0.667px.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1732769

Comparison between computed styles of Chrome DevTools and VisBug:
![CleanShot 2023-04-04 at 21 17 28](https://user-images.githubusercontent.com/56580353/229897822-5ee9f972-8588-430c-a8c0-aba35007ea25.png)

I would also like to thank all contributors for this amazing tool.
