### PR TITLE
Rotate and Delete from the ground up

### DIFF
--- a/app/components/index.js
+++ b/app/components/index.js
@@ -8,6 +8,7 @@ export { Overlay }    from './selection/overlay.element'
 export { BoxModel }   from './selection/box-model.element'
 export { Corners }    from './selection/corners.element'
 export { Grip }       from './selection/grip.element'
+export { Rotation }   from './selection/rotation.element'
 
 export { Metatip }    from './metatip/metatip.element'
 export { Ally }       from './metatip/ally.element'

--- a/app/components/index.js
+++ b/app/components/index.js
@@ -9,6 +9,7 @@ export { BoxModel }   from './selection/box-model.element'
 export { Corners }    from './selection/corners.element'
 export { Grip }       from './selection/grip.element'
 export { Rotation }   from './selection/rotation.element'
+export { Delete }     from './selection/delete.element'
 
 export { Metatip }    from './metatip/metatip.element'
 export { Ally }       from './metatip/ally.element'

--- a/app/components/selection/delete.element.css
+++ b/app/components/selection/delete.element.css
@@ -8,7 +8,7 @@
 }
 
 :host button {
-  background: var(--theme-color);
+  background: var(--neon-pink);
   border: none;
   border-radius: 50%;
   width: 24px;

--- a/app/components/selection/delete.element.css
+++ b/app/components/selection/delete.element.css
@@ -1,0 +1,34 @@
+@import "../_variables.css";
+
+:host {
+  position: var(--position, absolute);
+  top: var(--top, 0);
+  left: var(--left, 0);
+  z-index: var(--layer-top);
+}
+
+:host button {
+  background: var(--theme-color);
+  border: none;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-weight: bold;
+  padding: 0;
+  transition: transform 0.2s ease;
+}
+
+:host button:hover {
+  transform: scale(1.1);
+}
+
+:host svg {
+  width: 16px;
+  height: 16px;
+  fill: currentColor;
+}

--- a/app/components/selection/delete.element.js
+++ b/app/components/selection/delete.element.js
@@ -1,0 +1,65 @@
+import { DeleteStyles } from '../styles.store'
+
+export class Delete extends HTMLElement {
+  constructor() {
+    super()
+    this.$shadow = this.attachShadow({mode: 'closed'})
+    this.styles = [DeleteStyles]
+    this.observers = []
+  }
+
+  addObservers(observers) {
+    this.observers = observers
+  }
+
+  connectedCallback() {
+    this.$shadow.adoptedStyleSheets = this.styles
+    this.$shadow.innerHTML = this.render()
+    
+    const deleteBtn = this.$shadow.querySelector('button')
+    deleteBtn.addEventListener('click', this.deleteElement.bind(this))
+  }
+
+  set position({el}) {
+    this.targetElement = el
+    const {top, right} = el.getBoundingClientRect()
+    const isFixed = getComputedStyle(el).position === 'fixed'
+
+    this.style.setProperty('--top', `${top + (isFixed ? 0 : window.scrollY)}px`)
+    this.style.setProperty('--left', `${right + 10}px`)
+    this.style.setProperty('--position', isFixed ? 'fixed' : 'absolute')
+  }
+
+  deleteElement(e) {
+    e.preventDefault()
+    e.stopPropagation()
+    
+    if (!this.targetElement) {
+      console.warn('No target element found to delete')
+      return
+    }
+
+    this.observers.forEach(observer => observer.disconnect())
+
+    this.targetElement.remove()
+    
+    const labelId = this.targetElement.getAttribute('data-label-id')
+    if (labelId) {
+      document.querySelectorAll(`[data-label-id="${labelId}"]`).forEach(el => el.remove())
+    }
+    
+    this.remove()
+  }
+
+  render() {
+    return `
+      <button type="button" aria-label="Delete element">
+        <svg viewBox="0 0 24 24">
+          <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+        </svg>
+      </button>
+    `
+  }
+}
+
+customElements.define('visbug-delete', Delete)

--- a/app/components/selection/delete.element.js
+++ b/app/components/selection/delete.element.js
@@ -12,6 +12,10 @@ export class Delete extends HTMLElement {
     this.observers = observers
   }
 
+  set linkedElementsToDeleteToo(elements) {
+    this._linkedElementsToDeleteToo = elements
+  }
+
   connectedCallback() {
     this.$shadow.adoptedStyleSheets = this.styles
     this.$shadow.innerHTML = this.render()
@@ -40,7 +44,7 @@ export class Delete extends HTMLElement {
     }
 
     this.observers.forEach(observer => observer.disconnect())
-
+    this._linkedElementsToDeleteToo?.forEach(el => el.remove())
     this.targetElement.remove()
     
     const labelId = this.targetElement.getAttribute('data-label-id')

--- a/app/components/selection/delete.element.js
+++ b/app/components/selection/delete.element.js
@@ -1,4 +1,5 @@
 import { DeleteStyles } from '../styles.store'
+import { animateViewTransition } from '../../utilities/'
 
 export class Delete extends HTMLElement {
   constructor() {
@@ -34,7 +35,7 @@ export class Delete extends HTMLElement {
     this.style.setProperty('--position', isFixed ? 'fixed' : 'absolute')
   }
 
-  deleteElement(e) {
+  async deleteElement(e) {
     e.preventDefault()
     e.stopPropagation()
     
@@ -44,6 +45,18 @@ export class Delete extends HTMLElement {
     }
 
     this.observers.forEach(observer => observer.disconnect())
+
+    const elements = [
+      this.targetElement,
+      ...this._linkedElementsToDeleteToo || [],
+      ...Array.from(document.querySelectorAll(`[data-label-id="${this.targetElement.getAttribute('data-label-id')}"]`)),
+      this
+    ]
+
+    await animateViewTransition(elements, () => this.performDeletion())
+  }
+
+  performDeletion() {
     this._linkedElementsToDeleteToo?.forEach(el => el.remove())
     this.targetElement.remove()
     

--- a/app/components/selection/rotation.element.css
+++ b/app/components/selection/rotation.element.css
@@ -5,6 +5,7 @@
   top: var(--top);
   left: var(--left);
   pointer-events: none;
+  z-index: var(--layer-3);
 }
 
 :host .rotation-handle {
@@ -15,11 +16,13 @@
   left: calc(var(--width) / 2 - 12px);
   cursor: grab;
   pointer-events: all;
-  background: var(--theme-color);
+  background: var(--neon-pink);
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 :host .rotation-handle:active {
@@ -30,4 +33,5 @@
   width: 16px;
   height: 16px;
   fill: white;
+  pointer-events: none;
 }

--- a/app/components/selection/rotation.element.css
+++ b/app/components/selection/rotation.element.css
@@ -1,0 +1,33 @@
+@import "../_variables.css";
+
+:host {
+  position: var(--position);
+  top: var(--top);
+  left: var(--left);
+  pointer-events: none;
+}
+
+:host .rotation-handle {
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  top: -30px;
+  left: calc(var(--width) / 2 - 12px);
+  cursor: grab;
+  pointer-events: all;
+  background: var(--theme-color);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+:host .rotation-handle:active {
+  cursor: grabbing;
+}
+
+:host .rotation-icon {
+  width: 16px;
+  height: 16px;
+  fill: white;
+}

--- a/app/components/selection/rotation.element.css
+++ b/app/components/selection/rotation.element.css
@@ -8,6 +8,25 @@
   z-index: var(--layer-3);
 }
 
+:host .rotation-line {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+:host .rotation-line.active {
+  display: block;
+}
+
+:host .rotation-line line {
+  stroke: var(--neon-pink);
+  stroke-width: 1;
+}
+
 :host .rotation-handle {
   position: absolute;
   width: 24px;

--- a/app/components/selection/rotation.element.js
+++ b/app/components/selection/rotation.element.js
@@ -62,7 +62,11 @@ export class Rotation extends HTMLElement {
       this.currentAngle += rotation
       this.startAngle = angle
       
-      this.targetElement.style.transform = `rotate(${this.currentAngle * (180 / Math.PI)}deg)`
+      const rotationDegrees = this.currentAngle * (180 / Math.PI)
+      this.targetElement.style.transform = `rotate(${rotationDegrees}deg)`
+      
+      const handle = this.$shadow.querySelector('.rotation-handle')
+      handle.style.transform = `rotate(${rotationDegrees}deg)`
     }
 
     const onMouseUp = () => {

--- a/app/components/selection/rotation.element.js
+++ b/app/components/selection/rotation.element.js
@@ -5,8 +5,7 @@ export class Rotation extends HTMLElement {
     super()
     this.$shadow = this.attachShadow({mode: 'closed'})
     this.styles = [HandlesStyles, RotationStyles]
-    this.startAngle = 0
-    this.currentAngle = 0
+    this.totalAngle = 0
   }
 
   connectedCallback() {
@@ -42,7 +41,6 @@ export class Rotation extends HTMLElement {
         e.clientY - this.originalCenter.y,
         e.clientX - this.originalCenter.x
       )
-      this.currentAngle = 0
       
       this.handleRadius = Math.sqrt(
         Math.pow(e.clientX - this.originalCenter.x, 2) + 
@@ -70,25 +68,21 @@ export class Rotation extends HTMLElement {
       } else if (delta < -Math.PI) {
         delta += 2 * Math.PI
       }
-      this.currentAngle += delta
+      
+      this.totalAngle += delta
       this.lastAngle = currentAngle
       
-      const rotationDegrees = this.currentAngle * (180 / Math.PI)
+      const rotationDegrees = this.totalAngle * (180 / Math.PI)
       this.targetElement.style.transform = `rotate(${rotationDegrees}deg)`
       
-      this.handleRadius = Math.sqrt(
-        Math.pow(e.clientX - this.originalCenter.x, 2) + 
-        Math.pow(e.clientY - this.originalCenter.y, 2)
-      )
+      const handleX = e.clientX
+      const handleY = e.clientY
       
-      const handle = this.$shadow.querySelector('.rotation-handle')
+      const hostRect = this.getBoundingClientRect()
       const handleRect = handle.getBoundingClientRect()
       const handleSize = handleRect.width
       
-      const handleX = this.originalCenter.x + this.handleRadius * Math.cos(currentAngle)
-      const handleY = this.originalCenter.y + this.handleRadius * Math.sin(currentAngle)
-      
-      const hostRect = this.getBoundingClientRect()
+      // position handle centered on cursor
       handle.style.left = `${handleX - hostRect.left - handleSize/2}px`
       handle.style.top = `${handleY - hostRect.top - handleSize/2}px`
 
@@ -100,6 +94,7 @@ export class Rotation extends HTMLElement {
     }
 
     const onMouseUp = () => {
+      this.lastAngle = 0
       document.removeEventListener('mousemove', onMouseMove)
       document.removeEventListener('mouseup', onMouseUp)
       line.classList.remove('active')

--- a/app/components/selection/rotation.element.js
+++ b/app/components/selection/rotation.element.js
@@ -29,6 +29,7 @@ export class Rotation extends HTMLElement {
 
   setupRotationHandlers() {
     const handle = this.$shadow.querySelector('.rotation-handle')
+    const line = this.$shadow.querySelector('.rotation-line')
     
     const onMouseDown = e => {
       e.preventDefault()
@@ -46,6 +47,8 @@ export class Rotation extends HTMLElement {
         Math.pow(e.clientX - this.originalCenter.x, 2) + 
         Math.pow(e.clientY - this.originalCenter.y, 2)
       )
+      
+      line.classList.add('active')
       
       document.addEventListener('mousemove', onMouseMove)
       document.addEventListener('mouseup', onMouseUp)
@@ -78,11 +81,18 @@ export class Rotation extends HTMLElement {
       const hostRect = this.getBoundingClientRect()
       handle.style.left = `${handleX - hostRect.left - handleSize/2}px`
       handle.style.top = `${handleY - hostRect.top - handleSize/2}px`
+
+      const lineSvg = line.querySelector('line')
+      lineSvg.setAttribute('x1', this.originalCenter.x)
+      lineSvg.setAttribute('y1', this.originalCenter.y)
+      lineSvg.setAttribute('x2', handleX)
+      lineSvg.setAttribute('y2', handleY)
     }
 
     const onMouseUp = () => {
       document.removeEventListener('mousemove', onMouseMove)
       document.removeEventListener('mouseup', onMouseUp)
+      line.classList.remove('active')
     }
 
     handle.addEventListener('mousedown', onMouseDown)
@@ -98,6 +108,9 @@ export class Rotation extends HTMLElement {
 
   render() {
     return `
+      <svg class="rotation-line">
+        <line/>
+      </svg>
       <div class="rotation-handle">
         <svg class="rotation-icon" viewBox="0 0 24 24">
           <path d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"/>

--- a/app/components/selection/rotation.element.js
+++ b/app/components/selection/rotation.element.js
@@ -38,10 +38,11 @@ export class Rotation extends HTMLElement {
         x: left + width / 2,
         y: top + height / 2
       }
-      this.startAngle = Math.atan2(
+      this.lastAngle = Math.atan2(
         e.clientY - this.originalCenter.y,
         e.clientX - this.originalCenter.x
       )
+      this.currentAngle = 0
       
       this.handleRadius = Math.sqrt(
         Math.pow(e.clientX - this.originalCenter.x, 2) + 
@@ -60,8 +61,17 @@ export class Rotation extends HTMLElement {
         e.clientX - this.originalCenter.x
       )
       
-      const rotation = currentAngle - this.startAngle
-      this.currentAngle = rotation
+      // track accumulated rotation to allow multiple revolutions
+      if (!this.lastAngle) this.lastAngle = currentAngle
+      let delta = currentAngle - this.lastAngle
+      // normalize the delta to avoid "flipping" at boundary crossing
+      if (delta > Math.PI) {
+        delta -= 2 * Math.PI
+      } else if (delta < -Math.PI) {
+        delta += 2 * Math.PI
+      }
+      this.currentAngle += delta
+      this.lastAngle = currentAngle
       
       const rotationDegrees = this.currentAngle * (180 / Math.PI)
       this.targetElement.style.transform = `rotate(${rotationDegrees}deg)`

--- a/app/components/selection/rotation.element.js
+++ b/app/components/selection/rotation.element.js
@@ -1,0 +1,95 @@
+import { HandlesStyles, RotationStyles } from '../styles.store'
+
+export class Rotation extends HTMLElement {
+  constructor() {
+    super()
+    this.$shadow = this.attachShadow({mode: 'closed'})
+    this.styles = [HandlesStyles, RotationStyles]
+    this.startAngle = 0
+    this.currentAngle = 0
+  }
+
+  connectedCallback() {
+    this.$shadow.adoptedStyleSheets = this.styles
+  }
+
+  set position({el}) {
+    this.targetElement = el
+    const {left, top, width, height} = el.getBoundingClientRect()
+    const isFixed = getComputedStyle(el).position === 'fixed'
+
+    this.style.setProperty('--top', `${top + (isFixed ? 0 : window.scrollY)}px`)
+    this.style.setProperty('--left', `${left}px`)
+    this.style.setProperty('--position', isFixed ? 'fixed' : 'absolute')
+    this.style.setProperty('--width', `${width}px`)
+    
+    this.$shadow.innerHTML = this.render()
+    this.setupRotationHandlers()
+  }
+
+  setupRotationHandlers() {
+    const handle = this.$shadow.querySelector('.rotation-handle')
+    
+    const onMouseDown = e => {
+      e.preventDefault()
+      const {left, top, width, height} = this.targetElement.getBoundingClientRect()
+      const center = {
+        x: left + width / 2,
+        y: top + height / 2
+      }
+      this.startAngle = Math.atan2(
+        e.clientY - center.y,
+        e.clientX - center.x
+      )
+      
+      document.addEventListener('mousemove', onMouseMove)
+      document.addEventListener('mouseup', onMouseUp)
+    }
+
+    const onMouseMove = e => {
+      const {left, top, width, height} = this.targetElement.getBoundingClientRect()
+      const center = {
+        x: left + width / 2,
+        y: top + height / 2
+      }
+      
+      const angle = Math.atan2(
+        e.clientY - center.y,
+        e.clientX - center.x
+      )
+      
+      const rotation = angle - this.startAngle
+      this.currentAngle += rotation
+      this.startAngle = angle
+      
+      this.targetElement.style.transform = `rotate(${this.currentAngle * (180 / Math.PI)}deg)`
+    }
+
+    const onMouseUp = () => {
+      document.removeEventListener('mousemove', onMouseMove)
+      document.removeEventListener('mouseup', onMouseUp)
+    }
+
+    handle.addEventListener('mousedown', onMouseDown)
+    
+    this.cleanup = () => {
+      handle.removeEventListener('mousedown', onMouseDown)
+    }
+  }
+
+  disconnectedCallback() {
+    this.cleanup && this.cleanup()
+  }
+
+  render() {
+    return `
+      <div class="rotation-handle">
+        <svg class="rotation-icon" viewBox="0 0 24 24">
+          <path d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"/>
+        </svg>
+      </div>
+    `
+  }
+}
+
+customElements.define('visbug-rotation', Rotation)

--- a/app/components/selection/rotation.element.js
+++ b/app/components/selection/rotation.element.js
@@ -18,10 +18,6 @@ export class Rotation extends HTMLElement {
     const {left, top, width, height} = el.getBoundingClientRect()
     const isFixed = getComputedStyle(el).position === 'fixed'
 
-    if (!this.handleRadius) {
-      this.handleRadius = height / 2 + 30
-    }
-
     this.style.setProperty('--top', `${top + (isFixed ? 0 : window.scrollY)}px`)
     this.style.setProperty('--left', `${left}px`)
     this.style.setProperty('--position', isFixed ? 'fixed' : 'absolute')
@@ -46,6 +42,11 @@ export class Rotation extends HTMLElement {
         e.clientX - this.originalCenter.x
       )
       
+      this.handleRadius = Math.sqrt(
+        Math.pow(e.clientX - this.originalCenter.x, 2) + 
+        Math.pow(e.clientY - this.originalCenter.y, 2)
+      )
+      
       document.addEventListener('mousemove', onMouseMove)
       document.addEventListener('mouseup', onMouseUp)
     }
@@ -61,6 +62,11 @@ export class Rotation extends HTMLElement {
       
       const rotationDegrees = this.currentAngle * (180 / Math.PI)
       this.targetElement.style.transform = `rotate(${rotationDegrees}deg)`
+      
+      this.handleRadius = Math.sqrt(
+        Math.pow(e.clientX - this.originalCenter.x, 2) + 
+        Math.pow(e.clientY - this.originalCenter.y, 2)
+      )
       
       const handle = this.$shadow.querySelector('.rotation-handle')
       

--- a/app/components/selection/rotation.element.js
+++ b/app/components/selection/rotation.element.js
@@ -14,8 +14,12 @@ export class Rotation extends HTMLElement {
 
   set position({el}) {
     this.targetElement = el
+    
+    const computedStyle = getComputedStyle(el)
+    if (computedStyle.display === 'inline') el.style.display = 'inline-block'
+
     const {left, top, width, height} = el.getBoundingClientRect()
-    const isFixed = getComputedStyle(el).position === 'fixed'
+    const isFixed = computedStyle.position === 'fixed'
 
     this.style.setProperty('--top', `${top + (isFixed ? 0 : window.scrollY)}px`)
     this.style.setProperty('--left', `${left}px`)

--- a/app/components/selection/rotation.element.js
+++ b/app/components/selection/rotation.element.js
@@ -18,6 +18,10 @@ export class Rotation extends HTMLElement {
     const {left, top, width, height} = el.getBoundingClientRect()
     const isFixed = getComputedStyle(el).position === 'fixed'
 
+    if (!this.handleRadius) {
+      this.handleRadius = height / 2 + 30
+    }
+
     this.style.setProperty('--top', `${top + (isFixed ? 0 : window.scrollY)}px`)
     this.style.setProperty('--left', `${left}px`)
     this.style.setProperty('--position', isFixed ? 'fixed' : 'absolute')
@@ -33,13 +37,13 @@ export class Rotation extends HTMLElement {
     const onMouseDown = e => {
       e.preventDefault()
       const {left, top, width, height} = this.targetElement.getBoundingClientRect()
-      const center = {
+      this.originalCenter = {
         x: left + width / 2,
         y: top + height / 2
       }
       this.startAngle = Math.atan2(
-        e.clientY - center.y,
-        e.clientX - center.x
+        e.clientY - this.originalCenter.y,
+        e.clientX - this.originalCenter.x
       )
       
       document.addEventListener('mousemove', onMouseMove)
@@ -47,26 +51,25 @@ export class Rotation extends HTMLElement {
     }
 
     const onMouseMove = e => {
-      const {left, top, width, height} = this.targetElement.getBoundingClientRect()
-      const center = {
-        x: left + width / 2,
-        y: top + height / 2
-      }
-      
-      const angle = Math.atan2(
-        e.clientY - center.y,
-        e.clientX - center.x
+      const currentAngle = Math.atan2(
+        e.clientY - this.originalCenter.y,
+        e.clientX - this.originalCenter.x
       )
       
-      const rotation = angle - this.startAngle
-      this.currentAngle += rotation
-      this.startAngle = angle
+      const rotation = currentAngle - this.startAngle
+      this.currentAngle = rotation
       
       const rotationDegrees = this.currentAngle * (180 / Math.PI)
       this.targetElement.style.transform = `rotate(${rotationDegrees}deg)`
       
       const handle = this.$shadow.querySelector('.rotation-handle')
-      handle.style.transform = `rotate(${rotationDegrees}deg)`
+      
+      const handleX = this.originalCenter.x + this.handleRadius * Math.cos(currentAngle)
+      const handleY = this.originalCenter.y + this.handleRadius * Math.sin(currentAngle)
+      
+      const hostRect = this.getBoundingClientRect()
+      handle.style.left = `${handleX - hostRect.left - 12}px`
+      handle.style.top = `${handleY - hostRect.top}px`
     }
 
     const onMouseUp = () => {

--- a/app/components/selection/rotation.element.js
+++ b/app/components/selection/rotation.element.js
@@ -69,13 +69,15 @@ export class Rotation extends HTMLElement {
       )
       
       const handle = this.$shadow.querySelector('.rotation-handle')
+      const handleRect = handle.getBoundingClientRect()
+      const handleSize = handleRect.width
       
       const handleX = this.originalCenter.x + this.handleRadius * Math.cos(currentAngle)
       const handleY = this.originalCenter.y + this.handleRadius * Math.sin(currentAngle)
       
       const hostRect = this.getBoundingClientRect()
-      handle.style.left = `${handleX - hostRect.left - 12}px`
-      handle.style.top = `${handleY - hostRect.top}px`
+      handle.style.left = `${handleX - hostRect.left - handleSize/2}px`
+      handle.style.top = `${handleY - hostRect.top - handleSize/2}px`
     }
 
     const onMouseUp = () => {

--- a/app/components/styles.store.js
+++ b/app/components/styles.store.js
@@ -14,6 +14,7 @@ import { default as boxmodel_css }   from './selection/box-model.element.css'
 import { default as metatip_css }    from './metatip/metatip.element.css'
 import { default as hotkeymap_css }  from './hotkey-map/base.element.css'
 import { default as grip_css }       from './selection/grip.element.css'
+import { default as rotation_css }   from './selection/rotation.element.css'
 
 import { default as light_css }            from './_variables_light.css'
 import { default as visbug_light_css }     from './vis-bug/vis-bug.element_light.css'
@@ -44,6 +45,7 @@ export const OverlayStyles        = constructStylesheet(overlay_css)
 export const BoxModelStyles       = constructStylesheet(boxmodel_css)
 export const HotkeymapStyles      = constructStylesheet(hotkeymap_css)
 export const GripStyles           = constructStylesheet(grip_css)
+export const RotationStyles       = constructStylesheet(rotation_css)
 
 export const LightTheme           = constructStylesheet(light_css)
 export const VisBugLightStyles    = constructStylesheet(visbug_light_css)

--- a/app/components/styles.store.js
+++ b/app/components/styles.store.js
@@ -15,6 +15,7 @@ import { default as metatip_css }    from './metatip/metatip.element.css'
 import { default as hotkeymap_css }  from './hotkey-map/base.element.css'
 import { default as grip_css }       from './selection/grip.element.css'
 import { default as rotation_css }   from './selection/rotation.element.css'
+import { default as delete_css }     from './selection/delete.element.css'
 
 import { default as light_css }            from './_variables_light.css'
 import { default as visbug_light_css }     from './vis-bug/vis-bug.element_light.css'
@@ -46,6 +47,7 @@ export const BoxModelStyles       = constructStylesheet(boxmodel_css)
 export const HotkeymapStyles      = constructStylesheet(hotkeymap_css)
 export const GripStyles           = constructStylesheet(grip_css)
 export const RotationStyles       = constructStylesheet(rotation_css)
+export const DeleteStyles         = constructStylesheet(delete_css)
 
 export const LightTheme           = constructStylesheet(light_css)
 export const VisBugLightStyles    = constructStylesheet(visbug_light_css)

--- a/app/components/vis-bug/vis-bug.element.js
+++ b/app/components/vis-bug/vis-bug.element.js
@@ -3,7 +3,7 @@ import hotkeys    from 'hotkeys-js'
 
 import {
   Handles, Handle, Label, Overlay, Gridlines, Corners,
-  Hotkeys, Metatip, Ally, Distance, BoxModel, Grip
+  Hotkeys, Metatip, Ally, Distance, BoxModel, Grip, Rotation
 } from '../'
 
 import {

--- a/app/components/vis-bug/vis-bug.element.js
+++ b/app/components/vis-bug/vis-bug.element.js
@@ -3,7 +3,7 @@ import hotkeys    from 'hotkeys-js'
 
 import {
   Handles, Handle, Label, Overlay, Gridlines, Corners,
-  Hotkeys, Metatip, Ally, Distance, BoxModel, Grip, Rotation
+  Hotkeys, Metatip, Ally, Distance, BoxModel, Grip, Rotation, Delete
 } from '../'
 
 import {

--- a/app/features/position.js
+++ b/app/features/position.js
@@ -27,10 +27,8 @@ export function Position() {
     state.elements.forEach(el =>
       el.teardown())
 
-    state.elements = els.map(el => {
-      draggable({el})
-      return el
-    })
+    state.elements = els.map(el =>
+      draggable({el}))
   }
 
   const disconnect = () => {
@@ -160,16 +158,6 @@ export function draggable({el, surface = el, cursor = 'move', clickEvent}) {
 
   setup()
   el.teardown = teardown
-
-  return el
-}
-
-export function rotatable({el}) {
-  const rotation = document.createElement('visbug-rotation')
-  document.body.appendChild(rotation)
-  rotation.position = {el}
-
-  el.teardown = () => rotation.remove()
 
   return el
 }

--- a/app/features/position.js
+++ b/app/features/position.js
@@ -27,8 +27,11 @@ export function Position() {
     state.elements.forEach(el =>
       el.teardown())
 
-    state.elements = els.map(el =>
-      draggable({el}))
+    state.elements = els.map(el => {
+      draggable({el})
+      rotatable({el})
+      return el
+    })
   }
 
   const disconnect = () => {
@@ -158,6 +161,16 @@ export function draggable({el, surface = el, cursor = 'move', clickEvent}) {
 
   setup()
   el.teardown = teardown
+
+  return el
+}
+
+export function rotatable({el}) {
+  const rotation = document.createElement('visbug-rotation')
+  document.body.appendChild(rotation)
+  rotation.position = {el}
+
+  el.teardown = () => rotation.remove()
 
   return el
 }

--- a/app/features/position.js
+++ b/app/features/position.js
@@ -29,7 +29,6 @@ export function Position() {
 
     state.elements = els.map(el => {
       draggable({el})
-      rotatable({el})
       return el
     })
   }

--- a/app/features/selectable.js
+++ b/app/features/selectable.js
@@ -429,7 +429,7 @@ export function Selectable(visbug) {
     if (tool === 'guides') {
       handles.forEach(handle => {
         handle.hidePopover &&  handle.hidePopover()
-        handle.showPopover && handle.showPopover()
+        if (handle.isConnected && handle.showPopover) handle.showPopover()
       })
     }
   }
@@ -456,7 +456,7 @@ export function Selectable(visbug) {
 
     $('visbug-metatip, visbug-ally').forEach(tip => {
       tip.hidePopover && tip.hidePopover()
-      tip.showPopover && tip.showPopover()
+      if (tip.isConnected && tip.showPopover) tip.showPopover()
     })
 
     selected.unshift(el)

--- a/app/features/selectable.js
+++ b/app/features/selectable.js
@@ -19,6 +19,8 @@ import {
   getTextShadowValues, isFixed, onRemove
 } from '../utilities/'
 
+import '../components/selection/delete.element.js'
+
 export function Selectable(visbug) {
   const page              = document.body
   let selected            = []
@@ -483,6 +485,7 @@ export function Selectable(visbug) {
       ...$('visbug-label'),
       ...$('visbug-hover'),
       ...$('visbug-distance'),
+      ...$('visbug-delete'),
     ]).forEach(el =>
       el.remove())
 
@@ -576,11 +579,18 @@ export function Selectable(visbug) {
           template: handleLabelText(el, visbug.activeTool)
         })
 
+    const deleteBtn = document.createElement('visbug-delete')
+    deleteBtn.position = {el}
+    
     let observer        = createObserver(el, {handle,label})
     let parentObserver  = createObserver(el, {handle,label})
 
-    observer.observe(el, { attributes: true })
-    parentObserver.observe(el.parentNode, { childList:true, subtree:true })
+    if (el) observer.observe(el, { attributes: true })
+    if (el.parentNode) parentObserver.observe(el.parentNode, { childList:true, subtree:true })
+      
+    deleteBtn.addObservers([observer, parentObserver])
+
+    document.body.appendChild(deleteBtn)
 
     if (label !== null) {
       onRemove(label, () => {

--- a/app/features/selectable.js
+++ b/app/features/selectable.js
@@ -19,8 +19,6 @@ import {
   getTextShadowValues, isFixed, onRemove
 } from '../utilities/'
 
-import '../components/selection/delete.element.js'
-
 export function Selectable(visbug) {
   const page              = document.body
   let selected            = []

--- a/app/features/selectable.js
+++ b/app/features/selectable.js
@@ -16,7 +16,7 @@ import {
   metaKey, htmlStringToDom, createClassname, camelToDash,
   isOffBounds, getStyle, getStyles, deepElementFromPoint, getShadowValues,
   isSelectorValid, findNearestChildElement, findNearestParentElement,
-  getTextShadowValues, isFixed, onRemove
+  getTextShadowValues, isFixed, onRemove, animateViewTransition
 } from '../utilities/'
 
 export function Selectable(visbug) {
@@ -159,8 +159,8 @@ export function Selectable(visbug) {
     e.preventDefault()
   }
 
-  const on_delete = e =>
-    selected.length && delete_all()
+  const on_delete = async e =>
+    selected.length && await delete_all()
 
   const on_clearstyles = e =>
     selected.forEach(el =>
@@ -497,13 +497,28 @@ export function Selectable(visbug) {
     !silent && tellWatchers()
   }
 
-  const delete_all = () => {
+  const delete_all = async () => {
     const selected_after_delete = selected.map(el => {
       if (canMoveRight(el))     return canMoveRight(el)
       else if (canMoveLeft(el)) return canMoveLeft(el)
       else if (el.parentNode)   return el.parentNode
     })
 
+    const elements = [
+      ...selected, 
+      ...labels, 
+      ...handles,
+      rotationBtn,
+      deleteBtn
+    ].filter(Boolean)
+
+    await animateViewTransition(elements, () => performDeletion())
+
+    selected_after_delete.forEach(el =>
+      select(el))
+  }
+
+  const performDeletion = () => {
     Array.from([
       ...selected, 
       ...labels, 
@@ -511,15 +526,12 @@ export function Selectable(visbug) {
       rotationBtn,
       deleteBtn
     ]).forEach(el => el.remove())
-
+    
     labels      = []
     handles     = []
     selected    = []
     rotationBtn = null
     deleteBtn   = null
-
-    selected_after_delete.forEach(el =>
-      select(el))
   }
 
   const expandSelection = ({query, all = false}) => {

--- a/app/features/selectable.js
+++ b/app/features/selectable.js
@@ -486,6 +486,7 @@ export function Selectable(visbug) {
       ...$('visbug-hover'),
       ...$('visbug-distance'),
       ...$('visbug-delete'),
+      ...$('visbug-rotation'),
     ]).forEach(el =>
       el.remove())
 
@@ -580,7 +581,12 @@ export function Selectable(visbug) {
         })
 
     const deleteBtn = document.createElement('visbug-delete')
+    const rotationBtn = document.createElement('visbug-rotation')
+    rotationBtn.position = {el}
+    rotationBtn.setAttribute('data-label-id', id)
+
     deleteBtn.position = {el}
+    deleteBtn.linkedElementsToDeleteToo = [rotationBtn]
     
     let observer        = createObserver(el, {handle,label})
     let parentObserver  = createObserver(el, {handle,label})
@@ -589,8 +595,9 @@ export function Selectable(visbug) {
     if (el.parentNode) parentObserver.observe(el.parentNode, { childList:true, subtree:true })
       
     deleteBtn.addObservers([observer, parentObserver])
-
+    
     document.body.appendChild(deleteBtn)
+    document.body.appendChild(rotationBtn)
 
     if (label !== null) {
       onRemove(label, () => {

--- a/app/features/selectable.js
+++ b/app/features/selectable.js
@@ -25,6 +25,8 @@ export function Selectable(visbug) {
   let selectedCallbacks   = []
   let labels              = []
   let handles             = []
+  let rotationBtn         = null
+  let deleteBtn           = null
 
   const hover_state       = {
     target:   null,
@@ -502,12 +504,19 @@ export function Selectable(visbug) {
       else if (el.parentNode)   return el.parentNode
     })
 
-    Array.from([...selected, ...labels, ...handles]).forEach(el =>
-      el.remove())
+    Array.from([
+      ...selected, 
+      ...labels, 
+      ...handles,
+      rotationBtn,
+      deleteBtn
+    ]).forEach(el => el.remove())
 
-    labels    = []
-    handles   = []
-    selected  = []
+    labels      = []
+    handles     = []
+    selected    = []
+    rotationBtn = null
+    deleteBtn   = null
 
     selected_after_delete.forEach(el =>
       select(el))
@@ -578,8 +587,8 @@ export function Selectable(visbug) {
           template: handleLabelText(el, visbug.activeTool)
         })
 
-    const deleteBtn = document.createElement('visbug-delete')
-    const rotationBtn = document.createElement('visbug-rotation')
+    deleteBtn = document.createElement('visbug-delete')
+    rotationBtn = document.createElement('visbug-rotation')
     rotationBtn.position = {el}
     rotationBtn.setAttribute('data-label-id', id)
 

--- a/app/utilities/common.js
+++ b/app/utilities/common.js
@@ -89,6 +89,7 @@ export const isOffBounds = node =>
     || node.closest('visbug-corners')
     || node.closest('visbug-grip')
     || node.closest('visbug-gridlines')
+    || node.closest('visbug-rotation')
   )
 
 export const isSelectorValid = (qs => (

--- a/app/utilities/common.js
+++ b/app/utilities/common.js
@@ -132,3 +132,24 @@ export const onRemove = (element, callback) => {
     childList: true,
   })
 }
+
+export async function animateViewTransition(elements, callback) {
+  if (document.startViewTransition) {
+    const transition = document.startViewTransition(() => 
+      callback()
+    )
+    await transition.finished
+  } else {
+    const animations = elements.map(el => 
+      el.animate([
+        { opacity: 1, transform: 'scale(1)' },
+        { opacity: 0, transform: 'scale(0.95)' }
+      ], {
+        duration: 200,
+        easing: 'ease-out'
+      })
+    )
+    await Promise.all(animations.map(animation => animation.finished))
+    callback()
+  }
+}

--- a/app/utilities/common.js
+++ b/app/utilities/common.js
@@ -90,6 +90,7 @@ export const isOffBounds = node =>
     || node.closest('visbug-grip')
     || node.closest('visbug-gridlines')
     || node.closest('visbug-rotation')
+    || node.closest('visbug-delete')
   )
 
 export const isSelectorValid = (qs => (

--- a/app/utilities/strings.js
+++ b/app/utilities/strings.js
@@ -44,4 +44,4 @@ export const altKey = window.navigator.platform.includes('Mac')
   ? 'opt'
   : 'alt'
 
-export const notList = ':not(vis-bug):not(script):not(hotkey-map):not(.visbug-metatip):not(visbug-label):not(visbug-handles):not(visbug-corners):not(visbug-grip):not(visbug-gridlines)'
+export const notList = ':not(vis-bug):not(script):not(hotkey-map):not(.visbug-metatip):not(visbug-label):not(visbug-handles):not(visbug-corners):not(visbug-grip):not(visbug-gridlines):not(visbug-rotation)'

--- a/app/utilities/strings.js
+++ b/app/utilities/strings.js
@@ -44,4 +44,4 @@ export const altKey = window.navigator.platform.includes('Mac')
   ? 'opt'
   : 'alt'
 
-export const notList = ':not(vis-bug):not(script):not(hotkey-map):not(.visbug-metatip):not(visbug-label):not(visbug-handles):not(visbug-corners):not(visbug-grip):not(visbug-gridlines):not(visbug-rotation)'
+export const notList = ':not(vis-bug):not(script):not(hotkey-map):not(.visbug-metatip):not(visbug-label):not(visbug-handles):not(visbug-corners):not(visbug-grip):not(visbug-gridlines):not(visbug-rotation):not(visbug-delete)'


### PR DESCRIPTION
follow-up to PR #657 (closes #657)

fixes #613 

- [x] create a new visbug-rotation handle-like element
- [x] write your own pointer down/move handlers
- [x] ~add new handle into handles~
  - [x] added both `<visbug-rotation>` and `<visbug-delete>` into selectable
- [x] create a visbug-delete element