### PR TITLE
Fix: guard against null line_model in distance.element position setter

### DIFF
--- a/app/components/selection/distance.element.js
+++ b/app/components/selection/distance.element.js
@@ -17,6 +17,8 @@ export class Distance extends HTMLElement {
   }
 
   set position({line_model, node_label_id}) {
+    if (!line_model) return
+
     this.styleProps = line_model
     this.$shadow.innerHTML  = this.render(line_model, node_label_id)
   }


### PR DESCRIPTION
## Summary

Fixes #686.

The `position` setter in `app/components/selection/distance.element.js` passed `line_model` directly into the `styleProps` setter and `render()`, both of which destructure it (`{y, x, d, q, v, color}` and `{q, d}` respectively).

When `line_model` is `null` or `undefined` — which can happen during rapid mouse movement or when measured elements dynamically unmount in single-page apps — destructuring throws a `TypeError` and crashes the measurement overlay.

## Change

Add an early-return guard at the top of the `position` setter so a falsy `line_model` is ignored instead of crashing:

```js
set position({line_model, node_label_id}) {
  if (!line_model) return

  this.styleProps = line_model
  this.$shadow.innerHTML = this.render(line_model, node_label_id)
}
```

Minimal, no behavior change for valid input.
